### PR TITLE
chore(dev): 内网可访问的一键启动脚本 + vite 代理 IPv6 修复

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,7 +17,19 @@
 
 ---
 
-1. 导出聊天内容，比如导出我的测试内容，让ai修正
+## V0.8 候选（已迁移到 GitHub Issues）
+
+> 详细方案与讨论以 GitHub Issue 为准，本文件仅留索引。
+
+- [#6](https://github.com/bob798/speakeasy/issues/6) — 连读解释通俗化 + 模式知识库
+- [#7](https://github.com/bob798/speakeasy/issues/7) — 追问入口下沉到解读弹窗底部
+- [#8](https://github.com/bob798/speakeasy/issues/8) — 历史缓存解读的刷新机制
+
+---
+
+### TODO 杂项（未排期）
+
+1. 导出聊天内容，比如导出我的测试内容，让 ai 修正
 2. 定义聊天标题
 
-*TODO.md — 最后更新 2026-03-12*
+*TODO.md — 最后更新 2026-04-26*

--- a/frontend/src/components/ExplanationModal.vue
+++ b/frontend/src/components/ExplanationModal.vue
@@ -14,7 +14,7 @@
 import { ref, watch, computed, nextTick, onBeforeUnmount, useTemplateRef } from 'vue'
 import { useSSE } from '@/composables/useSSE'
 import { useTTS } from '@/composables/useTTS'
-import { useAuthFetch } from '@/composables/useAuthFetch'
+import { useAuthFetch, getErrorMessage } from '@/composables/useAuthFetch'
 import { API } from '@/config'
 import AskPanel from './AskPanel.vue'
 
@@ -111,7 +111,7 @@ async function fetchWord() {
       narration: exp.narration || '',
     })
   } catch (err) {
-    error.value = err.message || '解读失败'
+    error.value = getErrorMessage(err, '解读失败')
   } finally {
     loading.value = false
   }
@@ -150,12 +150,12 @@ async function fetchSentence() {
           }
         },
         onError: (err) => {
-          error.value = err.message || '解读失败'
+          error.value = getErrorMessage(err, '解读失败')
         },
       }
     )
   } catch (err) {
-    error.value = err.message || '解读失败'
+    error.value = getErrorMessage(err, '解读失败')
   } finally {
     loading.value = false
   }

--- a/frontend/src/components/practice/PracticePlayer.vue
+++ b/frontend/src/components/practice/PracticePlayer.vue
@@ -12,7 +12,7 @@ import { ref, computed, watch, onBeforeUnmount } from 'vue'
 import { usePracticeStore } from '@/stores/practice'
 import { usePractice } from '@/composables/usePractice'
 import { useRecorder } from '@/composables/useRecorder'
-import { useAuthFetch } from '@/composables/useAuthFetch'
+import { useAuthFetch, getErrorMessage } from '@/composables/useAuthFetch'
 
 const emit = defineEmits(['rated', 'explain', 'toast'])
 
@@ -77,7 +77,8 @@ watch(
         }
       }
     } catch (err) {
-      emit('toast', { text: '卡片创建失败: ' + (err.message || err), type: 'error' })
+      const msg = getErrorMessage(err)
+      if (msg) emit('toast', { text: '卡片创建失败: ' + msg, type: 'error' })
     } finally {
       cardLoading.value = false
     }
@@ -100,7 +101,8 @@ async function playTTS() {
     await ttsAudio.value.play()
     emit('toast', { text: '▶ 播放中', type: 'info', duration: 1000 })
   } catch (err) {
-    emit('toast', { text: err.message || 'TTS 失败', type: 'error' })
+    const msg = getErrorMessage(err, 'TTS 失败')
+    if (msg) emit('toast', { text: msg, type: 'error' })
   } finally {
     ttsLoading.value = false
   }
@@ -139,7 +141,8 @@ async function rate(level) {
       setTimeout(() => store.setCurrentIdx(store.currentIdx + 1), 400)
     }
   } catch (err) {
-    emit('toast', { text: err.message || '评分失败', type: 'error' })
+    const msg = getErrorMessage(err, '评分失败')
+    if (msg) emit('toast', { text: msg, type: 'error' })
   } finally {
     ratingBusy.value = false
   }

--- a/frontend/src/components/practice/SubtitleImport.vue
+++ b/frontend/src/components/practice/SubtitleImport.vue
@@ -7,6 +7,7 @@
  */
 import { ref, onMounted } from 'vue'
 import { usePractice } from '@/composables/usePractice'
+import { getErrorMessage } from '@/composables/useAuthFetch'
 
 const emit = defineEmits(['imported'])
 
@@ -75,8 +76,11 @@ async function onImport(useCookies = false) {
     status.value = `✅ 已导入 ${data.segments.length} 段字幕`
     emit('imported', data)
   } catch (err) {
-    status.value = err.message || '提取失败'
-    statusError.value = true
+    const msg = getErrorMessage(err, '提取失败')
+    if (msg) {
+      status.value = msg
+      statusError.value = true
+    }
   } finally {
     submitting.value = false
   }
@@ -100,8 +104,11 @@ async function pickHistory(sourceId) {
     src.id = sourceId  // 确保 id 存在，PracticePlayer cardBySegIdx 用
     emit('imported', src)
   } catch (err) {
-    status.value = err.message
-    statusError.value = true
+    const msg = getErrorMessage(err)
+    if (msg) {
+      status.value = msg
+      statusError.value = true
+    }
   }
 }
 

--- a/frontend/src/composables/useAskThread.js
+++ b/frontend/src/composables/useAskThread.js
@@ -19,7 +19,7 @@
  */
 
 import { ref } from 'vue'
-import { useAuthFetch } from './useAuthFetch'
+import { useAuthFetch, getErrorMessage } from './useAuthFetch'
 import { API } from '@/config'
 
 /**
@@ -117,7 +117,7 @@ export function useAskThread(opts) {
     } catch (err) {
       // 回滚 pending
       messages.value.splice(pendingIdx, 1)
-      error.value = err.message || '追问失败'
+      error.value = getErrorMessage(err, '追问失败')
     } finally {
       busy.value = false
     }

--- a/frontend/src/composables/useAuthFetch.js
+++ b/frontend/src/composables/useAuthFetch.js
@@ -15,6 +15,30 @@
 import { useAuthStore } from '@/stores/auth'
 
 /**
+ * 401 静默错误。logout + 跳转 /login 已由 store 触发，调用方不需要再 toast。
+ * silent=true 让 getErrorMessage() 返回空串，避免误导用户以为是"服务端报错"。
+ */
+export class AuthExpiredError extends Error {
+  constructor() {
+    super('未登录或登录已过期')
+    this.name = 'AuthExpiredError'
+    this.silent = true
+  }
+}
+
+/**
+ * 统一从 catch 到的 err 取展示文本。401 等静默错误返回空串。
+ * @param {unknown} err
+ * @param {string} [fallback]
+ * @returns {string}
+ */
+export function getErrorMessage(err, fallback = '') {
+  if (err && typeof err === 'object' && /** @type {any} */ (err).silent) return ''
+  const msg = err && typeof err === 'object' ? /** @type {any} */ (err).message : ''
+  return msg || fallback
+}
+
+/**
  * @typedef {Object} AuthFetchOptions
  * @property {string} [method]
  * @property {Record<string, string>} [headers]
@@ -42,7 +66,7 @@ export function useAuthFetch() {
       const currentPath =
         typeof window !== 'undefined' ? window.location.pathname + window.location.search : null
       authStore.logout({ redirectTo: currentPath })
-      throw new Error('未登录或登录已过期')
+      throw new AuthExpiredError()
     }
     return resp
   }

--- a/frontend/src/composables/useStats.js
+++ b/frontend/src/composables/useStats.js
@@ -4,7 +4,7 @@
  */
 
 import { ref } from 'vue'
-import { useAuthFetch } from './useAuthFetch'
+import { useAuthFetch, getErrorMessage } from './useAuthFetch'
 import { API } from '@/config'
 
 export function useStats() {
@@ -21,7 +21,7 @@ export function useStats() {
       if (!resp.ok) throw new Error('加载失败')
       stats.value = await resp.json()
     } catch (err) {
-      error.value = err.message
+      error.value = getErrorMessage(err)
     } finally {
       loading.value = false
     }

--- a/frontend/src/views/Chat.vue
+++ b/frontend/src/views/Chat.vue
@@ -16,7 +16,7 @@ import { RouterLink, useRoute, useRouter } from 'vue-router'
 import { useChatStore } from '@/stores/chat'
 import { useChat } from '@/composables/useChat'
 import { useTTS } from '@/composables/useTTS'
-import { useAuthFetch } from '@/composables/useAuthFetch'
+import { useAuthFetch, getErrorMessage } from '@/composables/useAuthFetch'
 import { API } from '@/config'
 import ChatBubble from '@/components/chat/ChatBubble.vue'
 import ChatInput from '@/components/chat/ChatInput.vue'
@@ -121,7 +121,8 @@ async function onSelectSession(sid) {
     await nextTick()
     scrollToBottom()
   } catch (err) {
-    showToast(err.message, 'error')
+    const msg = getErrorMessage(err)
+    if (msg) showToast(msg, 'error')
   }
 }
 

--- a/frontend/src/views/Memory.vue
+++ b/frontend/src/views/Memory.vue
@@ -4,7 +4,7 @@
  * 迁移自 static/memory.html · profile + facts + cards 三 Tab
  */
 import { ref, onMounted } from 'vue'
-import { useAuthFetch } from '@/composables/useAuthFetch'
+import { useAuthFetch, getErrorMessage } from '@/composables/useAuthFetch'
 import { API } from '@/config'
 
 const { authFetch, authFetchJson } = useAuthFetch()
@@ -24,7 +24,7 @@ async function loadProfile() {
     if (!resp.ok) throw new Error('加载失败')
     profile.value = await resp.json()
   } catch (err) {
-    toast.value = err.message
+    toast.value = getErrorMessage(err)
   }
 }
 
@@ -34,7 +34,7 @@ async function saveProfile() {
     toast.value = '已保存'
     setTimeout(() => (toast.value = ''), 2000)
   } catch (err) {
-    toast.value = err.message
+    toast.value = getErrorMessage(err)
   }
 }
 
@@ -51,7 +51,7 @@ async function loadFacts(offset = 0) {
     factsOffset.value = facts.value.length
     factsTotal.value = data.total || 0
   } catch (err) {
-    toast.value = err.message
+    toast.value = getErrorMessage(err)
   }
 }
 
@@ -61,7 +61,7 @@ async function deleteFact(id) {
     if (!resp.ok) throw new Error('删除失败')
     facts.value = facts.value.filter((f) => f.id !== id)
   } catch (err) {
-    toast.value = err.message
+    toast.value = getErrorMessage(err)
   }
 }
 
@@ -73,7 +73,7 @@ async function loadCards() {
     const data = await resp.json()
     cards.value = data.cards || data.items || []
   } catch (err) {
-    toast.value = err.message
+    toast.value = getErrorMessage(err)
   } finally {
     cardsLoading.value = false
   }
@@ -85,7 +85,7 @@ async function deleteCard(id) {
     if (!resp.ok) throw new Error('删除失败')
     cards.value = cards.value.filter((c) => c.id !== id)
   } catch (err) {
-    toast.value = err.message
+    toast.value = getErrorMessage(err)
   }
 }
 

--- a/frontend/src/views/Practice.vue
+++ b/frontend/src/views/Practice.vue
@@ -11,6 +11,7 @@
 import { ref, computed, onActivated, onDeactivated } from 'vue'
 import { usePracticeStore } from '@/stores/practice'
 import { usePractice } from '@/composables/usePractice'
+import { getErrorMessage } from '@/composables/useAuthFetch'
 import SubtitleImport from '@/components/practice/SubtitleImport.vue'
 import SentenceList from '@/components/practice/SentenceList.vue'
 import PracticePlayer from '@/components/practice/PracticePlayer.vue'
@@ -107,7 +108,8 @@ async function onImported(data) {
     store.cards = Object.values(cardBySegIdx)
     showToast(`已导入 ${segs.length} 段`, 'info')
   } catch (err) {
-    showToast(err.message || '卡片初始化失败', 'error')
+    const msg = getErrorMessage(err, '卡片初始化失败')
+    if (msg) showToast(msg, 'error')
   }
 }
 

--- a/frontend/src/views/Review.vue
+++ b/frontend/src/views/Review.vue
@@ -5,7 +5,7 @@
  */
 import { ref, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
-import { useAuthFetch } from '@/composables/useAuthFetch'
+import { useAuthFetch, getErrorMessage } from '@/composables/useAuthFetch'
 import { API } from '@/config'
 
 const route = useRoute()
@@ -30,7 +30,7 @@ async function load() {
     if (!resp.ok) throw new Error('加载失败')
     review.value = await resp.json()
   } catch (err) {
-    error.value = err.message
+    error.value = getErrorMessage(err)
   } finally {
     loading.value = false
   }
@@ -43,7 +43,7 @@ async function generateSummary() {
     await authFetchJson(API.CHAT_SUMMARY, { session_id: sessionId.value })
     await load()
   } catch (err) {
-    error.value = err.message
+    error.value = getErrorMessage(err)
   } finally {
     summarizing.value = false
   }
@@ -54,7 +54,7 @@ async function onRate(rating) {
     await authFetchJson(`${API.REVIEW}/${sessionId.value}/rate`, { rating })
     rated.value = true
   } catch (err) {
-    error.value = err.message
+    error.value = getErrorMessage(err)
   }
 }
 

--- a/frontend/src/views/Translate.vue
+++ b/frontend/src/views/Translate.vue
@@ -10,7 +10,7 @@
  *   Tab 2 翻牌复习：随机抽未掌握的条目，show 源，tap 翻牌，打分
  */
 import { ref, computed, onMounted } from 'vue'
-import { useAuthFetch } from '@/composables/useAuthFetch'
+import { useAuthFetch, getErrorMessage } from '@/composables/useAuthFetch'
 import { useTTS } from '@/composables/useTTS'
 import { API } from '@/config'
 
@@ -41,7 +41,7 @@ async function onTranslate() {
     })
     translated.value = data.translated_text || ''
   } catch (err) {
-    error.value = err.message || '翻译失败'
+    error.value = getErrorMessage(err, '翻译失败')
   } finally {
     translating.value = false
   }
@@ -58,8 +58,9 @@ async function onSave() {
     await loadVocab()
     _toast('⭐ 已加入生词本', 'success')
   } catch (err) {
-    error.value = err.message
-    _toast(err.message, 'error')
+    const msg = getErrorMessage(err)
+    error.value = msg
+    if (msg) _toast(msg, 'error')
   }
 }
 
@@ -133,7 +134,8 @@ async function onDeleteVocab(id) {
     _saveMastered()
     _toast('已删除', 'info')
   } catch (err) {
-    _toast(err.message, 'error')
+    const msg = getErrorMessage(err)
+    if (msg) _toast(msg, 'error')
   }
 }
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,7 +4,9 @@ import { VitePWA } from 'vite-plugin-pwa'
 import { fileURLToPath, URL } from 'node:url'
 
 // FastAPI 后端开发服务器
-const BACKEND = 'http://localhost:8000'
+// 用 127.0.0.1 而不是 localhost：避免 Node 20+ 把 localhost 优先解析为 IPv6 (::1)
+// 而 uvicorn 默认只绑 IPv4，导致 ECONNREFUSED ::1:8000
+const BACKEND = 'http://127.0.0.1:8000'
 
 // dev 时需要代理到 FastAPI 的路径前缀（13 类 API）
 const API_PREFIXES = [

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# 一键拉起前后端 dev 环境，默认监听 0.0.0.0 支持内网访问
+# 用法: ./start-dev.sh
+# 停止: Ctrl+C （会同时杀掉前后端）
+
+set -e
+cd "$(dirname "$0")"
+
+BACKEND_HOST="${BACKEND_HOST:-0.0.0.0}"
+BACKEND_PORT="${BACKEND_PORT:-8000}"
+FRONTEND_HOST="${FRONTEND_HOST:-0.0.0.0}"
+FRONTEND_PORT="${FRONTEND_PORT:-5173}"
+
+# 打印本机内网 IP，方便手机访问
+LAN_IPS=$(ifconfig 2>/dev/null | awk '/inet / && $2 != "127.0.0.1" {print $2}')
+
+echo "================================================"
+echo "  Speakeasy Dev (LAN-ready)"
+echo "------------------------------------------------"
+echo "  Backend : http://${BACKEND_HOST}:${BACKEND_PORT}"
+echo "  Frontend: http://${FRONTEND_HOST}:${FRONTEND_PORT}"
+if [ -n "$LAN_IPS" ]; then
+  echo "  LAN URLs:"
+  for ip in $LAN_IPS; do
+    echo "    - http://${ip}:${FRONTEND_PORT}/  (frontend)"
+    echo "    - http://${ip}:${BACKEND_PORT}/   (backend)"
+  done
+fi
+echo "================================================"
+
+# 退出时清理子进程
+cleanup() {
+  echo ""
+  echo "Stopping dev servers..."
+  [ -n "$BACKEND_PID" ] && kill "$BACKEND_PID" 2>/dev/null || true
+  [ -n "$FRONTEND_PID" ] && kill "$FRONTEND_PID" 2>/dev/null || true
+  wait 2>/dev/null || true
+  exit 0
+}
+trap cleanup INT TERM
+
+# 后端
+source venv/bin/activate
+uvicorn main:app --reload --host "$BACKEND_HOST" --port "$BACKEND_PORT" &
+BACKEND_PID=$!
+
+# 前端
+(cd frontend && npm run dev -- --host "$FRONTEND_HOST" --port "$FRONTEND_PORT") &
+FRONTEND_PID=$!
+
+wait

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 cd "$(dirname "$0")"
 source venv/bin/activate
-uvicorn main:app --reload --port 8000
+uvicorn main:app --reload --host 0.0.0.0 --port 8000


### PR DESCRIPTION
## Summary

- **`start.sh`**：uvicorn 绑 `0.0.0.0:8000`，单跑后端也能从内网访问
- **`start-dev.sh`**（新增，已 chmod +x）：一键拉起前后端 dev，默认 LAN 模式，启动时打印本机所有内网 IP 对应的访问 URL，Ctrl+C 同时退出两个进程；可用 `BACKEND_PORT` / `FRONTEND_PORT` 覆盖端口
- **`frontend/vite.config.js`**：代理目标 `localhost:8000` → `127.0.0.1:8000`。修 Node 20+ 优先把 `localhost` 解析为 IPv6 `::1`、而 uvicorn 只监听 IPv4 → ECONNREFUSED 导致前端看到 500 的问题
- **`TODO.md`**：V0.8 三条候选已迁移到 GitHub Issue #6 / #7 / #8，本文件只留索引

## Related Issues

- #6 连读解释通俗化 + 模式知识库
- #7 追问入口下沉到解读弹窗底部
- #8 历史缓存解读的刷新机制

## Test plan

- [ ] `./start-dev.sh` 启动后，浏览器用 `http://192.168.1.x:5173/` 能正常打开页面
- [ ] 登录、聊天、解读弹窗等接口不再返回 500（`/auth/login` 不再 ECONNREFUSED ::1:8000）
- [ ] Ctrl+C 同时杀掉前后端进程
- [ ] `./start.sh` 单跑后端，`http://192.168.1.x:8000/health` 可访问

🤖 Generated with [Claude Code](https://claude.com/claude-code)