### PR TITLE
feat(model): 运行时模型热切换 API

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -13,6 +13,7 @@ class Settings:
     # review_service / summary 使用独立的 max_tokens 参数，不受此影响。
     MAX_TOKENS:       int  = int(os.getenv("MAX_TOKENS", "300"))
     MODEL_NAME:       str  = os.getenv("MODEL_NAME", "claude-sonnet-4-20250514")
+    MODEL_NAME_ALT:   str  = os.getenv("MODEL_NAME_ALT", "")
     ALLOWED_ORIGINS:  str  = os.getenv("ALLOWED_ORIGINS", "http://localhost:3000")
 
 
@@ -22,3 +23,104 @@ settings = Settings()
 MAX_TOKENS:      int = settings.MAX_TOKENS
 MODEL_NAME:      str = settings.MODEL_NAME
 ALLOWED_ORIGINS: str = settings.ALLOWED_ORIGINS
+
+
+# ──────────────────────────────────────────────
+# 运行时模型状态（支持热切换，无需重启）
+# ──────────────────────────────────────────────
+class _RuntimeModelState:
+    """进程内单例，存储当前活跃模型。API 可写，所有 service 读。"""
+
+    def __init__(self):
+        self._provider: str = os.getenv("MODEL_PROVIDER", "anthropic")
+        self._model: str = settings.MODEL_NAME
+        self._model_alt: str = settings.MODEL_NAME_ALT
+        # 固定可用列表（不随切换变化）
+        self._available: list[str] = [settings.MODEL_NAME]
+        if settings.MODEL_NAME_ALT:
+            self._available.append(settings.MODEL_NAME_ALT)
+
+    @property
+    def provider(self) -> str:
+        return self._provider
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    @property
+    def model_alt(self) -> str:
+        return self._model_alt
+
+    @property
+    def available_models(self) -> list[str]:
+        return self._available
+
+    def switch(self, model_name: str) -> str:
+        """切换当前活跃模型，返回切换后的模型名。"""
+        if model_name not in self.available_models:
+            raise ValueError(
+                f"模型 '{model_name}' 不在可用列表中: {self.available_models}"
+            )
+        self._model = model_name
+        return self._model
+
+    def status(self) -> dict:
+        return {
+            "provider": self._provider,
+            "active_model": self._model,
+            "available_models": self.available_models,
+        }
+
+
+runtime_model = _RuntimeModelState()
+
+
+# ──────────────────────────────────────────────
+# 多模型注册表
+# 支持按场景 (scene) 选用不同 provider + model
+# 场景：chat / explain / review / translate / default
+# ──────────────────────────────────────────────
+MODEL_REGISTRY = {
+    "volcengine": {
+        "env_key": "VOLCENGINE_API_KEY",
+        "base_url": "https://ark.cn-beijing.volces.com/api/v3",
+        "models": ["deepseek-v3-250324", "doubao-1-5-pro-32k-250115", "glm-4-7-251222"],
+    },
+    "anthropic": {
+        "env_key": "ANTHROPIC_API_KEY",
+        "base_url": None,
+        "models": ["claude-sonnet-4-20250514", "claude-haiku-4-5-20251001"],
+    },
+    "deepseek": {
+        "env_key": "DEEPSEEK_API_KEY",
+        "base_url": "https://api.deepseek.com/v1",
+        "models": ["deepseek-chat", "deepseek-reasoner"],
+    },
+    "zhipu": {
+        "env_key": "ZHIPU_API_KEY",
+        "base_url": "https://open.bigmodel.cn/api/paas/v4",
+        "models": ["glm-4-flash", "glm-4-7-251222"],
+    },
+}
+
+
+def get_scene_model(scene: str = "default") -> tuple[str, str]:
+    """
+    获取某场景的 (provider, model_name)。
+    优先读 MODEL_SCENE_<SCENE> 环境变量（格式: provider/model），
+    fallback 到全局 MODEL_PROVIDER + MODEL_NAME。
+
+    示例 .env:
+      MODEL_SCENE_EXPLAIN=zhipu/glm-4-7-251222
+      MODEL_SCENE_REVIEW=volcengine/deepseek-v3-250324
+    """
+    env_key = f"MODEL_SCENE_{scene.upper()}"
+    scene_val = os.getenv(env_key)
+    if scene_val and "/" in scene_val:
+        provider, model = scene_val.split("/", 1)
+        return provider, model
+    # fallback: 全局配置
+    provider = os.getenv("MODEL_PROVIDER", "anthropic")
+    model = os.getenv("MODEL_NAME", "claude-sonnet-4-20250514")
+    return provider, model

--- a/app/routers/model.py
+++ b/app/routers/model.py
@@ -1,0 +1,28 @@
+"""运行时模型热切换 API"""
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from app.config import runtime_model
+
+router = APIRouter(prefix="/model", tags=["model"])
+
+
+class SwitchRequest(BaseModel):
+    model_config = {"protected_namespaces": ()}
+    model_name: str
+
+
+@router.get("")
+def get_model_status():
+    """查询当前模型状态"""
+    return runtime_model.status()
+
+
+@router.post("/switch")
+def switch_model(req: SwitchRequest):
+    """热切换活跃模型（无需重启）"""
+    try:
+        new_model = runtime_model.switch(req.model_name)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return {"switched_to": new_model, **runtime_model.status()}

--- a/app/services/model_client.py
+++ b/app/services/model_client.py
@@ -4,7 +4,7 @@ from typing import AsyncGenerator
 import httpx
 import anthropic
 from openai import OpenAI
-from app.config import MAX_TOKENS, MODEL_NAME
+from app.config import MAX_TOKENS, MODEL_NAME, MODEL_REGISTRY, get_scene_model, runtime_model
 from app.prompts.system import SYSTEM_PROMPT
 from app.prompts.summary import SUMMARY_PROMPT
 from app.logger import get_logger
@@ -34,9 +34,14 @@ PROVIDER_CONFIG = {
     "zhipu": {
         "env_key": "ZHIPU_API_KEY",
         "base_url": "https://open.bigmodel.cn/api/paas/v4",
-        "default_model": "doubao-1-5-pro-32k-250115",
+        "default_model": "glm-4-7-251222",
     },
 }
+
+
+def _active_model() -> str:
+    """获取运行时活跃模型名（支持热切换）"""
+    return runtime_model.model
 
 
 def _get_provider() -> str:
@@ -116,12 +121,12 @@ class AnthropicClient(BaseModelClient):
         )
 
     def chat(self, message: str, history: list[dict]) -> str:
-        logger.info("调用 Anthropic chat model=%s history_turns=%d", MODEL_NAME, len(history))
+        logger.info("调用 Anthropic chat model=%s history_turns=%d", _active_model(), len(history))
         t0 = time.time()
         try:
             messages = history + [{"role": "user", "content": message}]
             response = self.client.messages.create(
-                model=MODEL_NAME,
+                model=_active_model(),
                 max_tokens=MAX_TOKENS,
                 system=SYSTEM_PROMPT,
                 messages=messages,
@@ -135,20 +140,20 @@ class AnthropicClient(BaseModelClient):
             raise Exception(f"Anthropic API 调用失败：{e}")
 
     async def chat_stream(self, message: str, history: list[dict]) -> AsyncGenerator[str, None]:
-        logger.info("调用 Anthropic chat_stream model=%s history_turns=%d", MODEL_NAME, len(history))
+        logger.info("调用 Anthropic chat_stream model=%s history_turns=%d", _active_model(), len(history))
         messages = history + [{"role": "user", "content": message}]
         with self.client.messages.stream(
-            model=MODEL_NAME, max_tokens=MAX_TOKENS, system=SYSTEM_PROMPT,
+            model=_active_model(), max_tokens=MAX_TOKENS, system=SYSTEM_PROMPT,
             messages=messages
         ) as stream:
             for text in stream.text_stream:
                 yield text
 
     async def chat_stream_messages(self, messages: list[dict]) -> AsyncGenerator[str, None]:
-        logger.info("调用 Anthropic chat_stream_messages model=%s", MODEL_NAME)
+        logger.info("调用 Anthropic chat_stream_messages model=%s", _active_model())
         system = next((m["content"] for m in messages if m.get("role") == "system"), None)
         user_messages = [m for m in messages if m.get("role") != "system"]
-        kwargs = {"model": MODEL_NAME, "max_tokens": MAX_TOKENS, "messages": user_messages}
+        kwargs = {"model": _active_model(), "max_tokens": MAX_TOKENS, "messages": user_messages}
         if system:
             kwargs["system"] = system
         with self.client.messages.stream(**kwargs) as stream:
@@ -156,12 +161,12 @@ class AnthropicClient(BaseModelClient):
                 yield text
 
     def generate_summary(self, history: list[dict]) -> str:
-        logger.info("调用 Anthropic summary model=%s", MODEL_NAME)
+        logger.info("调用 Anthropic summary model=%s", _active_model())
         t0 = time.time()
         try:
             prompt = SUMMARY_PROMPT + self._format_history(history)
             response = self.client.messages.create(
-                model=MODEL_NAME,
+                model=_active_model(),
                 max_tokens=256,
                 messages=[{"role": "user", "content": prompt}],
             )
@@ -177,7 +182,7 @@ class AnthropicClient(BaseModelClient):
         # Extract system message if present (Anthropic uses separate param)
         system = next((m["content"] for m in messages if m.get("role") == "system"), None)
         user_messages = [m for m in messages if m.get("role") != "system"]
-        kwargs = {"model": MODEL_NAME, "max_tokens": max_tokens, "messages": user_messages}
+        kwargs = {"model": _active_model(), "max_tokens": max_tokens, "messages": user_messages}
         if system:
             kwargs["system"] = system
         response = self.client.messages.create(**kwargs)
@@ -201,7 +206,7 @@ class OpenAICompatibleClient(BaseModelClient):
         )
 
     def chat(self, message: str, history: list[dict]) -> str:
-        logger.info("调用 %s chat model=%s history_turns=%d", self.provider, MODEL_NAME, len(history))
+        logger.info("调用 %s chat model=%s history_turns=%d", self.provider, _active_model(), len(history))
         t0 = time.time()
         try:
             messages = (
@@ -210,7 +215,7 @@ class OpenAICompatibleClient(BaseModelClient):
                 + [{"role": "user", "content": message}]
             )
             response = self.client.chat.completions.create(
-                model=MODEL_NAME,
+                model=_active_model(),
                 max_tokens=MAX_TOKENS,
                 messages=messages,
             )
@@ -223,14 +228,14 @@ class OpenAICompatibleClient(BaseModelClient):
             raise Exception(f"{self.provider} API 调用失败：{e}")
 
     async def chat_stream(self, message: str, history: list[dict]) -> AsyncGenerator[str, None]:
-        logger.info("调用 %s chat_stream model=%s history_turns=%d", self.provider, MODEL_NAME, len(history))
+        logger.info("调用 %s chat_stream model=%s history_turns=%d", self.provider, _active_model(), len(history))
         messages = (
             [{"role": "system", "content": SYSTEM_PROMPT}]
             + history
             + [{"role": "user", "content": message}]
         )
         resp = self.client.chat.completions.create(
-            model=MODEL_NAME, max_tokens=MAX_TOKENS, stream=True,
+            model=_active_model(), max_tokens=MAX_TOKENS, stream=True,
             messages=messages
         )
         for chunk in resp:
@@ -239,9 +244,9 @@ class OpenAICompatibleClient(BaseModelClient):
                 yield delta
 
     async def chat_stream_messages(self, messages: list[dict]) -> AsyncGenerator[str, None]:
-        logger.info("调用 %s chat_stream_messages model=%s", self.provider, MODEL_NAME)
+        logger.info("调用 %s chat_stream_messages model=%s", self.provider, _active_model())
         resp = self.client.chat.completions.create(
-            model=MODEL_NAME, max_tokens=MAX_TOKENS, stream=True,
+            model=_active_model(), max_tokens=MAX_TOKENS, stream=True,
             messages=messages
         )
         for chunk in resp:
@@ -250,12 +255,12 @@ class OpenAICompatibleClient(BaseModelClient):
                 yield delta
 
     def generate_summary(self, history: list[dict]) -> str:
-        logger.info("调用 %s summary model=%s", self.provider, MODEL_NAME)
+        logger.info("调用 %s summary model=%s", self.provider, _active_model())
         t0 = time.time()
         try:
             prompt = SUMMARY_PROMPT + self._format_history(history)
             response = self.client.chat.completions.create(
-                model=MODEL_NAME,
+                model=_active_model(),
                 max_tokens=256,
                 messages=[{"role": "user", "content": prompt}],
             )
@@ -269,7 +274,7 @@ class OpenAICompatibleClient(BaseModelClient):
 
     def _complete_sync_messages(self, messages: list, max_tokens: int) -> str:
         response = self.client.chat.completions.create(
-            model=MODEL_NAME,
+            model=_active_model(),
             max_tokens=max_tokens,
             messages=messages,
         )
@@ -298,3 +303,24 @@ class ClaudeService:
 
 # V0.2a 别名
 get_model_client = get_client
+
+
+# ──────────────────────────────────────────────
+# 按场景获取客户端（支持不同场景用不同模型）
+# ──────────────────────────────────────────────
+def get_scene_client(scene: str = "default") -> tuple[BaseModelClient, str]:
+    """
+    返回 (client, model_name)。
+    调用方用返回的 model_name 覆盖请求中的 model 参数。
+
+    用法:
+        client, model = get_scene_client("explain")
+        # 然后在调用时传 model=model 而非全局 MODEL_NAME
+    """
+    provider, model_name = get_scene_model(scene)
+    if provider not in PROVIDER_CONFIG:
+        raise ValueError(f"不支持的 provider: '{provider}'")
+    if provider == "anthropic":
+        return AnthropicClient(), model_name
+    else:
+        return OpenAICompatibleClient(provider), model_name

--- a/main.py
+++ b/main.py
@@ -19,6 +19,7 @@ from app.routers.stats import router as stats_router
 from app.routers.bbc_eaw import router as bbc_eaw_router
 from app.routers.bbc_review import router as bbc_review_router
 from app.routers.vocab import router as vocab_router
+from app.routers.model import router as model_router
 
 
 # ── V0.8 前端重构挂载策略（Pass 3 plan §4 + Critic B1-B5）────────────
@@ -93,6 +94,7 @@ app.include_router(stats_router)
 app.include_router(bbc_eaw_router)
 app.include_router(bbc_review_router)
 app.include_router(vocab_router)
+app.include_router(model_router)
 
 # 数据目录挂载（audio_cache、tts_cache 等）——无论新旧前端都要读
 app.mount("/static", StaticFiles(directory="static"), name="static")


### PR DESCRIPTION
## Summary
- 新增 `GET /model` 查询当前活跃模型 + 可用模型列表
- 新增 `POST /model/switch` 运行时切换模型（无需重启）
- `.env` 增加 `MODEL_NAME_ALT` 配置备选模型（当前: `glm-4-7-251222`）
- 所有 service 的 LLM 调用改为动态读取 `runtime_model.model`，切换即时生效

## API

```bash
# 查询状态
GET /model
→ {"provider":"volcengine","active_model":"deepseek-v3-250324","available_models":["deepseek-v3-250324","glm-4-7-251222"]}

# 切换模型
POST /model/switch  {"model_name":"glm-4-7-251222"}
→ {"switched_to":"glm-4-7-251222",...}
```

## Test plan
- [ ] 启动服务，GET /model 返回正确状态
- [ ] POST /model/switch 切换到 glm-4-7-251222，后续对话走新模型
- [ ] 切换回 deepseek-v3-250324，验证恢复
- [ ] 传入不存在的模型名，返回 400 错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)