### PR TITLE
fix(deploy): 先 git pull 再调用 deploy_vps.sh

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,4 +68,5 @@ jobs:
           script: |
             set -e
             cd ${{ secrets.VPS_APP_DIR }}
-            CI=1 bash scripts/deploy_vps.sh
+            git pull --ff-only origin main
+            CI=1 SKIP_PULL=1 bash scripts/deploy_vps.sh


### PR DESCRIPTION
## Summary
- VPS 上脚本是旧版（内容是 HTML），需先 `git pull` 拿到最新 `deploy_vps.sh` 再执行
- 加 `SKIP_PULL=1` 避免脚本内重复 pull

## Root cause
workflow SSH 进 VPS 直接调 `scripts/deploy_vps.sh`，但 VPS 上还没有这个文件的最新版本

🤖 Generated with [Claude Code](https://claude.com/claude-code)