### PR TITLE
fix(deploy): 去掉 VPS git pull，避免国内网络超时

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,5 +68,4 @@ jobs:
           script: |
             set -e
             cd ${{ secrets.VPS_APP_DIR }}
-            git pull --ff-only origin main
             CI=1 SKIP_PULL=1 bash scripts/deploy_vps.sh


### PR DESCRIPTION
## Summary
- 腾讯云 VPS 访问 GitHub 不稳定（GnuTLS TLS 断连）
- 部署靠 ACR 镜像，VPS 上不需要最新源码
- `SKIP_PULL=1` 跳过脚本内的 git pull 和 docker pull（workflow 已单独 pull）

🤖 Generated with [Claude Code](https://claude.com/claude-code)