### PR TITLE
feat(practice): 手机端重设计 · 单作用对象 + coach bar + 底部 dock

### DIFF
--- a/docs/superpowers/plans/2026-05-12-practice-mobile-redesign.md
+++ b/docs/superpowers/plans/2026-05-12-practice-mobile-redesign.md
@@ -1,0 +1,1582 @@
+# Practice 手机端重设计 · 实现计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 把 Practice 页手机端（<768px）从「难找按钮的长滚动列表」改造为「单手大拇指可达 + 教练状态条引导」的练习页。桌面端不变。
+
+**Architecture:** Practice.vue 容器按 `isMobile` 切两套子组件树。手机端：`MobileSentenceList`（列表 + 当前句卡 + 选词）+ `MobileActionDock`（coach bar + 4 按钮）+ ⚙ 底部 sheet。`selectedWord` 等瞬时 UI 状态留在 `Practice.vue` 本地 ref（不入 Pinia），避免跨布局污染。Coach bar 文案由纯派生 composable `useCoachBar` 推导。
+
+**Tech Stack:** Vue 3 (`<script setup>`) · Pinia (复用现有 `usePracticeStore`) · vitest + @vue/test-utils (仅给纯派生 composable 写单测) · 设计 tokens (`frontend/src/styles/tokens.css`)
+
+**Spec:** `docs/superpowers/specs/2026-05-12-practice-mobile-redesign.md`
+**Prototype:** `mockups/practice-mobile-v2.html`
+**Branch:** `feat/practice-mobile-redesign`（已存在）
+
+---
+
+## File Structure
+
+```
+frontend/src/
+├── composables/
+│   ├── useBreakpoint.js                    [NEW] 通用 isMobile reactive (matchMedia)
+│   ├── useCoachBar.js                      [NEW] 纯派生：state → coach copy
+│   └── __tests__/
+│       └── useCoachBar.spec.js             [NEW] vitest 单测
+├── components/practice/
+│   ├── MobileSentenceList.vue              [NEW] 列表 + 当前句卡（含词拆分 + 选词 + 选中条）
+│   ├── MobileActionDock.vue                [NEW] coach bar + 4 按钮 + 主/副标签状态机
+│   ├── PracticePlayer.vue                  [UNCHANGED] 桌面端用
+│   ├── SentenceList.vue                    [UNCHANGED] 桌面端用
+│   └── SubtitleImport.vue                  [UNCHANGED]
+└── views/
+    └── Practice.vue                        [MODIFY] 按 isMobile 切换子树 + ⚙ sheet + 首次 FSRS toast + 状态机
+```
+
+**职责边界：**
+- `MobileSentenceList`：纯 UI，从 store 拿 `segments / currentIdx`，从 props 拿 `selectedWord`。emit `select-sentence` / `select-word` / `clear-word`。
+- `MobileActionDock`：纯 UI，从 props 拿状态（`selectedWord, recording, isPlayingTTS, hasRecording, hasPlayedBack, currentIdx, totalSegments, practicedCount`）。emit `explain` / `speak` / `toggle-record` / `playback` / `open-settings`。
+- `Practice.vue`：所有副作用（TTS、录音、API、storage、状态机原语）集中在这里。
+
+---
+
+## Phase 1 · Foundation 组件依赖
+
+### Task 1: `useBreakpoint` composable
+
+**Files:**
+- Create: `frontend/src/composables/useBreakpoint.js`
+
+- [ ] **Step 1: 创建 composable**
+
+```js
+// frontend/src/composables/useBreakpoint.js
+import { ref, onMounted, onUnmounted } from 'vue'
+
+/**
+ * 响应式 isMobile · 基于 matchMedia('(max-width: 767px)')
+ * 与 spec 的 < 768px 断点对齐
+ */
+export function useBreakpoint() {
+  const isMobile = ref(false)
+  let mq = null
+  const onChange = (e) => { isMobile.value = e.matches }
+
+  onMounted(() => {
+    mq = window.matchMedia('(max-width: 767px)')
+    isMobile.value = mq.matches
+    mq.addEventListener('change', onChange)
+  })
+  onUnmounted(() => {
+    if (mq) mq.removeEventListener('change', onChange)
+  })
+
+  return { isMobile }
+}
+```
+
+- [ ] **Step 2: 手动 sanity check**
+
+跑 `npm run dev`（在 `frontend/` 目录），打开 Practice 页（这步还没接入，但确保 import 不报 lint 错）。
+
+Run: `cd frontend && npm run lint -- src/composables/useBreakpoint.js`
+Expected: 无 error
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/composables/useBreakpoint.js
+git commit -m "feat(practice): add useBreakpoint composable"
+```
+
+---
+
+### Task 2: `useCoachBar` composable + 单测
+
+**Files:**
+- Create: `frontend/src/composables/useCoachBar.js`
+- Create: `frontend/src/composables/__tests__/useCoachBar.spec.js`
+
+- [ ] **Step 1: 先写测试（TDD）**
+
+```js
+// frontend/src/composables/__tests__/useCoachBar.spec.js
+import { describe, it, expect } from 'vitest'
+import { ref } from 'vue'
+import { useCoachBar } from '../useCoachBar'
+
+function setup(overrides = {}) {
+  const state = {
+    selectedWord:  ref(null),
+    recording:     ref(false),
+    isPlayingTTS:  ref(false),
+    hasRecording:  ref(false),
+    hasPlayedBack: ref(false),
+    currentIdx:    ref(0),
+    totalSegments: ref(9),
+    practicedCount: ref(0),
+    ...overrides,
+  }
+  return { state, ...useCoachBar(state) }
+}
+
+describe('useCoachBar', () => {
+  it('空闲：先听我读一次', () => {
+    const { coachCopy, coachProgress } = setup()
+    expect(coachCopy.value).toBe('先听我读一次')
+    expect(coachProgress.value).toBe('第 1/9 句')
+  })
+
+  it('选词后：解读 "<word>"', () => {
+    const { coachCopy } = setup({ selectedWord: ref({ word: 'schedule', display: 'schedule' }) })
+    expect(coachCopy.value).toBe('解读 "schedule"')
+  })
+
+  it('TTS 播放中：听着…', () => {
+    const { coachCopy } = setup({ isPlayingTTS: ref(true) })
+    expect(coachCopy.value).toBe('听着…')
+  })
+
+  it('录音中：录音中 · 念完点停止', () => {
+    const { coachCopy, coachClass } = setup({ recording: ref(true) })
+    expect(coachCopy.value).toBe('录音中 · 念完点停止')
+    expect(coachClass.value).toBe('recording')
+  })
+
+  it('录完未回放：收到了 · 回放听听自己', () => {
+    const { coachCopy } = setup({ hasRecording: ref(true) })
+    expect(coachCopy.value).toBe('收到了 · 回放听听自己')
+  })
+
+  it('录完已回放：比一比，节奏对齐了吗', () => {
+    const { coachCopy } = setup({
+      hasRecording: ref(true),
+      hasPlayedBack: ref(true),
+    })
+    expect(coachCopy.value).toBe('比一比，节奏对齐了吗')
+  })
+
+  it('已完成 N 句时进度带 · 已完成 N', () => {
+    const { coachProgress } = setup({
+      currentIdx: ref(2),
+      practicedCount: ref(3),
+    })
+    expect(coachProgress.value).toBe('第 3/9 句 · 已完成 3')
+  })
+
+  it('状态优先级：录音 > TTS > 选词 > 录完 > 空闲', () => {
+    // 录音中即使有 selectedWord 和 hasRecording 也走录音文案
+    const { coachCopy } = setup({
+      selectedWord: ref({ word: 'x', display: 'x' }),
+      hasRecording: ref(true),
+      recording: ref(true),
+    })
+    expect(coachCopy.value).toBe('录音中 · 念完点停止')
+  })
+})
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cd frontend && npm test -- useCoachBar`
+Expected: FAIL — `Cannot find module '../useCoachBar'`
+
+- [ ] **Step 3: 实现 composable**
+
+```js
+// frontend/src/composables/useCoachBar.js
+import { computed } from 'vue'
+
+/**
+ * Coach bar 状态机 · 纯派生 · 不持有 state
+ *
+ * 状态优先级：recording > isPlayingTTS > selectedWord > hasPlayedBack > hasRecording > idle
+ *
+ * @param {{
+ *   selectedWord:   import('vue').Ref<{word:string, display:string}|null>,
+ *   recording:      import('vue').Ref<boolean>,
+ *   isPlayingTTS:   import('vue').Ref<boolean>,
+ *   hasRecording:   import('vue').Ref<boolean>,
+ *   hasPlayedBack:  import('vue').Ref<boolean>,
+ *   currentIdx:     import('vue').Ref<number>,
+ *   totalSegments:  import('vue').Ref<number>,
+ *   practicedCount: import('vue').Ref<number>,
+ * }} state
+ */
+export function useCoachBar(state) {
+  const coachCopy = computed(() => {
+    if (state.recording.value) return '录音中 · 念完点停止'
+    if (state.isPlayingTTS.value) return '听着…'
+    if (state.selectedWord.value) return `解读 "${state.selectedWord.value.display}"`
+    if (state.hasRecording.value && state.hasPlayedBack.value) return '比一比，节奏对齐了吗'
+    if (state.hasRecording.value) return '收到了 · 回放听听自己'
+    return '先听我读一次'
+  })
+
+  const coachClass = computed(() => (state.recording.value ? 'recording' : ''))
+
+  const coachProgress = computed(() => {
+    const base = `第 ${state.currentIdx.value + 1}/${state.totalSegments.value} 句`
+    return state.practicedCount.value > 0
+      ? `${base} · 已完成 ${state.practicedCount.value}`
+      : base
+  })
+
+  return { coachCopy, coachClass, coachProgress }
+}
+```
+
+- [ ] **Step 4: 跑测试确认全过**
+
+Run: `cd frontend && npm test -- useCoachBar`
+Expected: PASS (8 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/composables/useCoachBar.js \
+        frontend/src/composables/__tests__/useCoachBar.spec.js
+git commit -m "feat(practice): add useCoachBar composable + tests"
+```
+
+---
+
+## Phase 2 · MobileActionDock 组件
+
+### Task 3: 创建 `MobileActionDock.vue` 骨架
+
+**Files:**
+- Create: `frontend/src/components/practice/MobileActionDock.vue`
+
+- [ ] **Step 1: 创建组件文件**
+
+```vue
+<!-- frontend/src/components/practice/MobileActionDock.vue -->
+<script setup>
+/**
+ * MobileActionDock · 手机端底部 action dock
+ *
+ * 仅 UI 与 props/emit；所有副作用在 Practice.vue。
+ * 设计文档：docs/superpowers/specs/2026-05-12-practice-mobile-redesign.md
+ *
+ * 该 dock 是可复用容器模式：未来 Translate / Polish 出现高频底部动作可沿用。
+ */
+import { computed } from 'vue'
+import { useCoachBar } from '@/composables/useCoachBar'
+
+const props = defineProps({
+  selectedWord:   { type: Object, default: null },
+  recording:      { type: Boolean, default: false },
+  isPlayingTTS:   { type: Boolean, default: false },
+  hasRecording:   { type: Boolean, default: false },
+  hasPlayedBack:  { type: Boolean, default: false },
+  currentIdx:     { type: Number, default: 0 },
+  totalSegments:  { type: Number, default: 0 },
+  practicedCount: { type: Number, default: 0 },
+})
+
+const emit = defineEmits(['explain', 'speak', 'toggle-record', 'playback'])
+
+// 把 props 转 refs 喂 useCoachBar
+const state = {
+  selectedWord:   computed(() => props.selectedWord),
+  recording:      computed(() => props.recording),
+  isPlayingTTS:   computed(() => props.isPlayingTTS),
+  hasRecording:   computed(() => props.hasRecording),
+  hasPlayedBack:  computed(() => props.hasPlayedBack),
+  currentIdx:     computed(() => props.currentIdx),
+  totalSegments:  computed(() => props.totalSegments),
+  practicedCount: computed(() => props.practicedCount),
+}
+const { coachCopy, coachClass, coachProgress } = useCoachBar(state)
+
+// 主标签：句模式 vs 词模式
+const explainLabel = computed(() => (props.selectedWord ? '解释单词' : '解释整句'))
+const speakLabel   = computed(() => (props.selectedWord ? '发音单词' : '发音整句'))
+const subWord      = computed(() => props.selectedWord?.display || '')
+
+const explainAria = computed(() =>
+  props.selectedWord
+    ? `解释 · 当前作用对象 ${props.selectedWord.display}`
+    : '解释 · 整句'
+)
+const speakAria = computed(() =>
+  props.selectedWord
+    ? `发音 · 当前作用对象 ${props.selectedWord.display}`
+    : '发音 · 整句'
+)
+
+const playbackDisabled = computed(() => !props.hasRecording)
+</script>
+
+<template>
+  <div class="dock">
+    <!-- coach bar -->
+    <div class="coach-bar" :class="coachClass" role="status" aria-live="polite">
+      <span class="ico" aria-hidden="true">🎯</span>
+      <span class="progress">{{ coachProgress }}</span>
+      <span class="copy">{{ coachCopy }}</span>
+    </div>
+
+    <div class="dock-row">
+      <button
+        class="dock-btn primary"
+        :aria-label="explainAria"
+        @click="emit('explain')"
+      >
+        <span class="ico" aria-hidden="true">💡</span>
+        <span class="label">{{ explainLabel }}</span>
+        <span v-if="subWord" class="sub">{{ subWord }}</span>
+      </button>
+      <button
+        class="dock-btn primary"
+        :aria-label="speakAria"
+        @click="emit('speak')"
+      >
+        <span class="ico" aria-hidden="true">🔊</span>
+        <span class="label">{{ speakLabel }}</span>
+        <span v-if="subWord" class="sub">{{ subWord }}</span>
+      </button>
+    </div>
+    <div class="dock-row">
+      <button
+        class="dock-btn record"
+        :class="{ recording }"
+        :aria-pressed="recording"
+        :aria-label="recording ? '停止录音' : '开始录音'"
+        @click="emit('toggle-record')"
+      >
+        <span class="ico" aria-hidden="true">{{ recording ? '⏹' : '🎤' }}</span>
+        <span class="label">{{ recording ? '停止' : '录音' }}</span>
+        <span class="sub">
+          {{ recording ? '录音中…' : (hasRecording ? '重录' : '开始录') }}
+        </span>
+      </button>
+      <button
+        class="dock-btn"
+        :aria-disabled="playbackDisabled"
+        :aria-label="playbackDisabled ? '回放，先录一段' : '回放录音'"
+        @click="emit('playback')"
+      >
+        <span class="ico" aria-hidden="true">▶</span>
+        <span class="label">回放</span>
+        <span class="sub">{{ playbackDisabled ? '无录音' : '听自己' }}</span>
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.dock {
+  position: sticky;
+  bottom: 0;
+  background: var(--bg-overlay);
+  backdrop-filter: saturate(180%) blur(20px);
+  -webkit-backdrop-filter: saturate(180%) blur(20px);
+  border-top: 1px solid var(--border);
+  padding: var(--space-2) var(--space-3);
+  padding-bottom: calc(var(--space-2) + var(--safe-bottom));
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  z-index: 5;
+}
+.coach-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px var(--space-3);
+  background: var(--bg-elevated);
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+  color: var(--text-2);
+  line-height: 1.35;
+}
+.coach-bar .ico { font-size: 14px; flex-shrink: 0; }
+.coach-bar .progress { color: var(--text-3); margin-right: 2px; flex-shrink: 0; }
+.coach-bar .copy { flex: 1; min-width: 0; }
+.coach-bar.recording { color: #c6463a; }
+
+.dock-row { display: flex; gap: var(--space-2); }
+.dock-btn {
+  flex: 1;
+  min-height: 56px;
+  border-radius: var(--radius);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  font-family: inherit;
+  color: var(--text-1);
+  cursor: pointer;
+  transition: all 120ms var(--ease);
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+}
+.dock-btn:active { transform: scale(0.96); background: var(--bg); }
+.dock-btn:focus { outline: none; }
+.dock-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.dock-btn .ico { font-size: 20px; line-height: 1; }
+.dock-btn .label { font-size: 13px; font-weight: 500; }
+.dock-btn .sub { font-size: 10px; color: var(--text-3); }
+.dock-btn.primary { background: var(--accent); border-color: var(--accent); color: var(--text-inverse); }
+.dock-btn.primary .sub { color: rgba(255,255,255,0.75); }
+.dock-btn.record.recording {
+  background: #c6463a; border-color: #c6463a; color: #fff;
+  animation: rec-pulse 1s infinite;
+}
+.dock-btn[aria-disabled="true"] { opacity: 0.45; }
+@keyframes rec-pulse {
+  0%,100% { box-shadow: 0 0 0 0 rgba(198,70,58,0.4); }
+  50%    { box-shadow: 0 0 0 8px rgba(198,70,58,0); }
+}
+
+@media (orientation: landscape) and (max-height: 500px) {
+  .dock { padding-bottom: var(--space-2); }
+  .dock-row { gap: var(--space-1); }
+  .dock-btn { min-height: 44px; }
+  .coach-bar { display: none; }
+}
+</style>
+```
+
+- [ ] **Step 2: Lint check**
+
+Run: `cd frontend && npm run lint -- src/components/practice/MobileActionDock.vue`
+Expected: 无 error
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/practice/MobileActionDock.vue
+git commit -m "feat(practice): add MobileActionDock component"
+```
+
+---
+
+## Phase 3 · MobileSentenceList 组件
+
+### Task 4: 创建 `MobileSentenceList.vue`
+
+**Files:**
+- Create: `frontend/src/components/practice/MobileSentenceList.vue`
+
+- [ ] **Step 1: 创建组件**
+
+```vue
+<!-- frontend/src/components/practice/MobileSentenceList.vue -->
+<script setup>
+/**
+ * MobileSentenceList · 手机端句子列表 + 当前句卡（含词拆分 + 选词）
+ *
+ * 仅 UI 与 emit；副作用在 Practice.vue。
+ */
+import { computed, nextTick, watch, useTemplateRef } from 'vue'
+import { usePracticeStore } from '@/stores/practice'
+
+const props = defineProps({
+  selectedWord: { type: Object, default: null }, // { word, display } | null
+})
+const emit = defineEmits([
+  'select-sentence',  // (idx: number)
+  'select-word',      // ({ word, display })
+  'clear-word',
+])
+
+const store = usePracticeStore()
+const segments = computed(() => store.segments)
+const currentIdx = computed(() => store.currentIdx)
+const listRef = useTemplateRef('listRef')
+
+// 拆词正则 · 标点保留为文本节点
+const WORD_RE = /([A-Za-z][A-Za-z'-]*)|([^A-Za-z]+)/g
+
+function tokenize(text) {
+  const out = []
+  let m
+  WORD_RE.lastIndex = 0
+  while ((m = WORD_RE.exec(text)) !== null) {
+    out.push(m[1] ? { type: 'word', text: m[1] } : { type: 'sep', text: m[2] })
+  }
+  return out
+}
+
+function isWordSelected(w) {
+  return !!props.selectedWord && props.selectedWord.word === w.toLowerCase()
+}
+
+function onWordClick(rawWord) {
+  const lower = rawWord.toLowerCase()
+  if (props.selectedWord && props.selectedWord.word === lower) {
+    emit('clear-word')
+  } else {
+    emit('select-word', { word: lower, display: rawWord })
+  }
+}
+
+function onSentenceClick(idx, ev) {
+  // 当前句内点词 / 选中条 时，不要触发选句
+  if (ev.target.closest('.word') || ev.target.closest('.selected-bar')) return
+  if (idx !== currentIdx.value) emit('select-sentence', idx)
+}
+
+// 当前句变化时滚到中央
+watch(
+  () => currentIdx.value,
+  async () => {
+    await nextTick()
+    const el = listRef.value?.querySelector(`[data-idx="${currentIdx.value}"]`)
+    if (el) el.scrollIntoView({ block: 'center', behavior: 'smooth' })
+  },
+  { immediate: true }
+)
+</script>
+
+<template>
+  <div ref="listRef" class="m-list">
+    <div
+      v-for="(seg, i) in segments"
+      :key="i"
+      :data-idx="i"
+      class="m-seg"
+      :class="{ current: i === currentIdx }"
+      @click="onSentenceClick(i, $event)"
+    >
+      <div class="idx">{{ i + 1 }}</div>
+      <div class="body">
+        <div class="txt">
+          <template v-if="i === currentIdx">
+            <template v-for="(tok, ti) in tokenize(seg.content)" :key="ti">
+              <button
+                v-if="tok.type === 'word'"
+                type="button"
+                class="word"
+                :aria-pressed="isWordSelected(tok.text)"
+                :aria-label="`单词 ${tok.text}${isWordSelected(tok.text) ? '（已选）' : ''}`"
+                @click.stop="onWordClick(tok.text)"
+              >{{ tok.text }}</button>
+              <template v-else>{{ tok.text }}</template>
+            </template>
+          </template>
+          <template v-else>{{ seg.content }}</template>
+        </div>
+
+        <div
+          v-if="i === currentIdx && selectedWord"
+          class="selected-bar"
+        >
+          <span>⭕ 已选：<b>{{ selectedWord.display }}</b></span>
+          <button
+            type="button"
+            class="clear"
+            aria-label="清除选中词"
+            @click.stop="emit('clear-word')"
+          >×</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.m-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-3) var(--space-4);
+  padding-bottom: var(--space-3);
+  scroll-behavior: smooth;
+}
+.m-seg {
+  display: flex;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  margin-bottom: var(--space-2);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background var(--duration) var(--ease);
+}
+.m-seg:active { background: var(--bg-elevated); }
+.m-seg .idx {
+  font-size: 12px;
+  color: var(--text-3);
+  width: 22px;
+  flex-shrink: 0;
+  padding-top: 3px;
+}
+.m-seg .body { flex: 1; min-width: 0; }
+.m-seg .txt {
+  font-size: 15px;
+  line-height: 1.55;
+  color: var(--text-2);
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  hyphens: auto;
+}
+.m-seg.current {
+  background: var(--bg-elevated);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.04), 0 4px 16px rgba(0,0,0,0.06);
+  border-left: 3px solid var(--accent);
+  padding-left: calc(var(--space-3) - 3px);
+}
+.m-seg.current .idx { color: var(--accent); font-weight: 600; }
+.m-seg.current .txt {
+  font-size: 18px;
+  font-weight: 500;
+  color: var(--text-1);
+}
+
+button.word {
+  display: inline-block;
+  padding: 1px 2px;
+  margin: 0 -1px;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  line-height: inherit;
+  border-radius: 3px;
+  cursor: pointer;
+  transition: background 120ms var(--ease);
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+}
+button.word:focus { outline: none; }
+button.word:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+button.word:active { background: var(--accent-soft); }
+button.word[aria-pressed="true"] {
+  background: var(--accent-soft);
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-decoration-color: var(--accent);
+  text-underline-offset: 3px;
+}
+
+.selected-bar {
+  margin-top: var(--space-3);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px var(--space-3);
+  background: var(--accent-soft);
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+  color: var(--accent);
+}
+.selected-bar .clear {
+  width: 24px; height: 24px;
+  display: grid; place-items: center;
+  border: none;
+  background: transparent;
+  border-radius: 50%;
+  color: var(--accent);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+}
+.selected-bar .clear:focus { outline: none; }
+.selected-bar .clear:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.selected-bar .clear:active { background: var(--bg-elevated); }
+</style>
+```
+
+- [ ] **Step 2: Lint check**
+
+Run: `cd frontend && npm run lint -- src/components/practice/MobileSentenceList.vue`
+Expected: 无 error
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/practice/MobileSentenceList.vue
+git commit -m "feat(practice): add MobileSentenceList component"
+```
+
+---
+
+## Phase 4 · Practice.vue 整合 + 状态机
+
+### Task 5: 改 `Practice.vue` 接入 mobile 子树
+
+**Files:**
+- Modify: `frontend/src/views/Practice.vue`
+
+这步改动较大，把 Phase 1-3 的组件全部接进 Practice.vue 并加状态机。
+
+- [ ] **Step 1: 改 `<script setup>` 顶部 imports + 状态**
+
+定位 `Practice.vue` 现有 imports 区（约第 11-21 行），把整个 script setup 替换为：
+
+```vue
+<script setup>
+/**
+ * Practice · V0.12 手机端重设计
+ *
+ * 桌面端 (>= 768px) 仍走 SentenceList + PracticePlayer（不动）。
+ * 手机端 (< 768px) 走 MobileSentenceList + MobileActionDock，
+ * 所有副作用（TTS / 录音 / API / 状态机）集中在本文件。
+ */
+import { ref, computed, watch, onActivated, onDeactivated, onBeforeUnmount } from 'vue'
+import { useRouter } from 'vue-router'
+import { usePracticeStore } from '@/stores/practice'
+import { usePractice } from '@/composables/usePractice'
+import { useRecorder } from '@/composables/useRecorder'
+import { useAuthFetch, getErrorMessage } from '@/composables/useAuthFetch'
+import { useScrollLock } from '@/composables/useScrollLock'
+import { useBreakpoint } from '@/composables/useBreakpoint'
+
+import SubtitleImport from '@/components/practice/SubtitleImport.vue'
+import SentenceList from '@/components/practice/SentenceList.vue'
+import PracticePlayer from '@/components/practice/PracticePlayer.vue'
+import MobileSentenceList from '@/components/practice/MobileSentenceList.vue'
+import MobileActionDock from '@/components/practice/MobileActionDock.vue'
+import ExplanationModal from '@/components/ExplanationModal.vue'
+
+defineOptions({ name: 'Practice' })
+
+const router = useRouter()
+const store = usePracticeStore()
+const { createCards, ttsBlob } = usePractice()
+const { authFetch } = useAuthFetch()
+const recorder = useRecorder()
+const { isMobile } = useBreakpoint()
+
+// ---- 通用 / 桌面端原有逻辑 ----
+const explainOpen = ref(false)
+const explainTarget = ref(null)
+const toast = ref({ show: false, text: '', type: 'info' })
+const listDrawerOpen = ref(false)  // 桌面端不用，但保留兼容
+useScrollLock(listDrawerOpen)
+
+const hasSource = computed(
+  () => !!store.currentSource && (store.segments?.length || 0) > 0
+)
+const isBbcSource = computed(() => {
+  const s = store.currentSource
+  return !!s && (s.source_type === 'bbc_eaw' || s.type === 'bbc_eaw')
+})
+
+function showToast(text, type = 'info', duration = 2500) {
+  toast.value = { show: true, text, type }
+  setTimeout(() => (toast.value.show = false), duration)
+}
+
+// ---- 手机端本地状态（不入 Pinia） ----
+const selectedWord = ref(null)         // { word, display } | null
+const sheetOpen = ref(false)
+const recordingSegIdx = ref(null)
+const hasPlayedBack = ref(false)
+const isPlayingTTS = ref(false)
+const practicedCount = ref(0)
+let _ttsAudio = null
+let _ttsUrl = null
+let _lastRequestKey = null
+
+useScrollLock(sheetOpen)
+
+const FSRS_NOTICE_KEY = 'v2:practice.fsrs_notice_seen'
+
+// 跨断点（resize 跨 768px）时清状态防泄漏
+watch(isMobile, () => {
+  selectedWord.value = null
+  sheetOpen.value = false
+  _releaseTTS()
+  if (recorder.recording.value) recorder.stop()
+  recordingSegIdx.value = null
+})
+
+// 首次进入弹一次 FSRS toast（仅手机端弹）
+watch(
+  [isMobile, hasSource],
+  ([m, has]) => {
+    if (!m || !has) return
+    try {
+      if (!localStorage.getItem(FSRS_NOTICE_KEY)) {
+        setTimeout(() => {
+          showToast('ℹ︎ 手机端暂不记录复习评分，仍可正常练习', 'info', 4000)
+          localStorage.setItem(FSRS_NOTICE_KEY, '1')
+        }, 400)
+      }
+    } catch { /* ignore */ }
+  },
+  { immediate: true }
+)
+
+// ---- 复用桌面端 onImported / onSelect / onExplain / onRated / onNewImport ----
+// (保持原 Practice.vue 现有实现；下面只列差异点)
+
+function gotoBbcReview() {
+  const slug = store.currentSource?.slug || store.currentSource?.id
+  if (!slug) return
+  router.push({ name: 'bbc-review', params: { slug } })
+}
+
+async function onImported(data) {
+  if (!data.id && data.source_id) data.id = data.source_id
+  store.loadSource(data)
+  const segs = (data.segments || []).map((seg, i) => ({
+    text: seg.content,
+    context: JSON.stringify({ segIdx: i, from: seg.from, to: seg.to }),
+    segIdx: i,
+  }))
+  try {
+    const existingResp = await fetch('/practice/cards?limit=200', {
+      headers: getAuthHeaders(),
+    })
+    const existingCards = existingResp.ok
+      ? ((await existingResp.json()).cards || [])
+      : []
+    const cardBySegIdx = {}
+    for (const c of existingCards) {
+      let segIdx = null
+      try {
+        const ctx = c.context ? JSON.parse(c.context) : {}
+        if (typeof ctx.segIdx === 'number') segIdx = ctx.segIdx
+      } catch { /* ignore */ }
+      if (segIdx == null) {
+        segIdx = segs.findIndex((s) => s.text === c.text)
+      }
+      if (segIdx >= 0 && segIdx < segs.length) {
+        cardBySegIdx[segIdx] = { ...c, segIdx }
+      }
+    }
+    const missing = segs.filter((_, i) => !cardBySegIdx[i])
+    if (missing.length) {
+      await createCards({ items: missing })
+      const refetchResp = await fetch('/practice/cards?limit=200', {
+        headers: getAuthHeaders(),
+      })
+      const refetched = refetchResp.ok
+        ? ((await refetchResp.json()).cards || [])
+        : []
+      for (const c of refetched) {
+        let segIdx = null
+        try {
+          const ctx = c.context ? JSON.parse(c.context) : {}
+          if (typeof ctx.segIdx === 'number') segIdx = ctx.segIdx
+        } catch { /* ignore */ }
+        if (segIdx == null) segIdx = segs.findIndex((s) => s.text === c.text)
+        if (segIdx >= 0 && segIdx < segs.length) {
+          cardBySegIdx[segIdx] = { ...c, segIdx }
+        }
+      }
+    }
+    store.cards = Object.values(cardBySegIdx)
+    showToast(`已导入 ${segs.length} 段`, 'info')
+  } catch (err) {
+    const msg = getErrorMessage(err, '卡片初始化失败')
+    if (msg) showToast(msg, 'error')
+  }
+}
+
+function getAuthHeaders() {
+  try {
+    const t = localStorage.getItem('v2:auth.token') || localStorage.getItem('token')
+    return t ? { Authorization: 'Bearer ' + t } : {}
+  } catch { return {} }
+}
+
+function onSelect(idx) {
+  store.setCurrentIdx(idx)
+  listDrawerOpen.value = false
+}
+
+function onExplain(payload) {
+  let target
+  if (typeof payload === 'string') {
+    target = { type: 'sentence', content: payload }
+  } else {
+    target = { type: payload.type, content: payload.content }
+    if (payload.sentence) target.sentence = payload.sentence
+  }
+  const src = store.currentSource || {}
+  const isBbc = src.source_type === 'bbc_eaw' || src.type === 'bbc_eaw'
+  const vocabRef = isBbc
+    ? { vocab_source_type: 'bbc_eaw', vocab_source_ref: src.slug || src.id || null }
+    : { vocab_source_type: 'practice', vocab_source_ref: src.id || src.source_id || null }
+  target.context = {
+    source: 'practice',
+    source_id: src.id,
+    ...vocabRef,
+    ...(target.sentence ? { sentence: target.sentence } : {}),
+  }
+  explainTarget.value = target
+  explainOpen.value = true
+}
+
+function onRated({ level }) {
+  showToast(`已评 ${level}`, 'info', 1200)
+}
+
+function onNewImport() {
+  store.reset()
+  sheetOpen.value = false
+}
+
+// ---- 手机端：选词 / 切句 / dock 动作 ----
+function _releaseTTS() {
+  if (_ttsAudio) { _ttsAudio.pause(); _ttsAudio = null }
+  if (_ttsUrl)   { URL.revokeObjectURL(_ttsUrl); _ttsUrl = null }
+  isPlayingTTS.value = false
+}
+
+function onMobileSelectSentence(idx) {
+  if (idx === store.currentIdx) return
+  // 状态机：录音中切句要 confirm
+  if (recorder.recording.value) {
+    const ok = window.confirm('正在录音，停止并切换到这一句？')
+    if (!ok) return
+    recorder.stop()
+    recorder.reset()
+    recordingSegIdx.value = null
+  }
+  _releaseTTS()
+  // 离开旧句视作"完成一句"（v1 用切句作信号；issue #26 评分恢复后改为按 Good/Easy 计）
+  if (store.currentIdx !== idx) practicedCount.value += 1
+  store.setCurrentIdx(idx)
+  selectedWord.value = null
+  hasPlayedBack.value = false
+}
+
+function onMobileSelectWord({ word, display }) {
+  selectedWord.value = { word, display }
+}
+function onMobileClearWord() {
+  selectedWord.value = null
+}
+
+async function onMobileExplain() {
+  const key = `explain:${store.currentIdx}:${selectedWord.value?.word || '__'}:${Date.now()}`
+  _lastRequestKey = key
+  if (selectedWord.value) {
+    onExplain({
+      type: 'word',
+      content: selectedWord.value.display,
+      sentence: store.currentSegment?.content || '',
+    })
+  } else {
+    onExplain(store.currentSegment?.content || '')
+  }
+  // stale 防御对 modal 打开本身意义不大（用户已切句也无影响），保留 key 写入便于一致语义
+  void key
+}
+
+async function onMobileSpeak() {
+  const key = `tts:${store.currentIdx}:${selectedWord.value?.word || '__'}:${Date.now()}`
+  _lastRequestKey = key
+  _releaseTTS()
+  isPlayingTTS.value = true
+  try {
+    const text = selectedWord.value ? selectedWord.value.display : (store.currentSegment?.content || '')
+    if (!text) return
+    const blob = await ttsBlob({
+      text,
+      provider: store.provider,
+      speed: store.speed,
+    })
+    if (_lastRequestKey !== key) return // stale 丢弃
+    _ttsUrl = URL.createObjectURL(blob)
+    _ttsAudio = new Audio(_ttsUrl)
+    _ttsAudio.onended = () => { if (_lastRequestKey === key) isPlayingTTS.value = false }
+    await _ttsAudio.play()
+  } catch (err) {
+    const msg = getErrorMessage(err, 'TTS 失败')
+    if (msg) showToast(msg, 'error')
+    isPlayingTTS.value = false
+  }
+}
+
+async function onMobileToggleRecord() {
+  if (recorder.recording.value) {
+    recorder.stop()
+    recordingSegIdx.value = null
+    hasPlayedBack.value = false
+  } else {
+    recorder.reset()
+    await recorder.start()
+    if (recorder.error.value) {
+      showToast(recorder.error.value, 'error')
+      return
+    }
+    recordingSegIdx.value = store.currentIdx
+  }
+}
+
+function onMobilePlayback() {
+  if (!recorder.url.value) {
+    showToast('先录一段', 'info', 1200)
+    return
+  }
+  const a = new Audio(recorder.url.value)
+  a.play()
+  hasPlayedBack.value = true
+}
+
+function onOpenSettings() { sheetOpen.value = true }
+function onCloseSettings() { sheetOpen.value = false }
+
+// 切句时清 TTS / 录音绑定校验
+watch(
+  () => store.currentIdx,
+  (n, o) => {
+    if (n === o) return
+    _releaseTTS()
+  }
+)
+
+onActivated(() => {})
+onDeactivated(() => {})
+onBeforeUnmount(() => {
+  _releaseTTS()
+  recorder.reset()
+})
+</script>
+```
+
+- [ ] **Step 2: 改 `<template>` —— 按 isMobile 切两套子树**
+
+把 `<template>` 整段替换为：
+
+```vue
+<template>
+  <div class="practice-page" :class="{ mobile: isMobile }">
+    <header class="topbar">
+      <RouterLink class="back" to="/">← 返回</RouterLink>
+      <div class="title">发音练习</div>
+      <div class="topbar-right">
+        <!-- 桌面端原有列表/重新导入按钮（mobile 不显示，移进 ⚙ sheet） -->
+        <template v-if="!isMobile">
+          <button
+            v-if="hasSource && isBbcSource"
+            class="bbc-btn"
+            @click="gotoBbcReview"
+            title="开始/继续这篇 BBC 文章的 SRS 复习"
+          >📖 复习</button>
+          <button
+            v-if="hasSource"
+            class="new-btn"
+            @click="onNewImport"
+            title="重新导入字幕"
+          >🔄</button>
+        </template>
+        <!-- 手机端：单一 ⚙ 设置入口 -->
+        <button
+          v-if="isMobile && hasSource"
+          class="settings-btn"
+          @click="onOpenSettings"
+          aria-label="打开设置"
+        >
+          <span aria-hidden="true">⚙</span>
+          <span>设置</span>
+        </button>
+      </div>
+    </header>
+
+    <div v-if="!hasSource" class="import-wrap">
+      <SubtitleImport @imported="onImported" />
+    </div>
+
+    <!-- 桌面端布局 -->
+    <div v-else-if="!isMobile" class="layout">
+      <aside class="left">
+        <div class="progress">
+          <div class="progress-bar" :style="{ width: `${store.progressPct}%` }"></div>
+        </div>
+        <div class="stats">
+          {{ store.totalPracticed }}/{{ store.segments.length }} 已练
+          · Again: {{ store.ratingResults.again }}
+          · Good: {{ store.ratingResults.good }}
+        </div>
+        <SentenceList @select="onSelect" @explain="onExplain" />
+      </aside>
+      <main class="right">
+        <PracticePlayer
+          @rated="onRated"
+          @explain="onExplain"
+          @toast="({ text, type, duration }) => showToast(text, type || 'info', duration || 2000)"
+        />
+      </main>
+    </div>
+
+    <!-- 手机端布局 -->
+    <template v-else>
+      <MobileSentenceList
+        :selected-word="selectedWord"
+        @select-sentence="onMobileSelectSentence"
+        @select-word="onMobileSelectWord"
+        @clear-word="onMobileClearWord"
+      />
+      <MobileActionDock
+        :selected-word="selectedWord"
+        :recording="recorder.recording.value"
+        :is-playing-t-t-s="isPlayingTTS"
+        :has-recording="!!recorder.url.value"
+        :has-played-back="hasPlayedBack"
+        :current-idx="store.currentIdx"
+        :total-segments="store.segments.length"
+        :practiced-count="practicedCount"
+        @explain="onMobileExplain"
+        @speak="onMobileSpeak"
+        @toggle-record="onMobileToggleRecord"
+        @playback="onMobilePlayback"
+      />
+    </template>
+
+    <!-- ⚙ 手机端 sheet -->
+    <Teleport to="body">
+      <Transition name="sheet">
+        <div
+          v-if="sheetOpen"
+          class="sheet-mask"
+          @click.self="onCloseSettings"
+          @keydown.esc="onCloseSettings"
+        >
+          <aside class="sheet" role="dialog" aria-modal="true" aria-labelledby="sheet-title">
+            <h4 id="sheet-title">设置</h4>
+            <div class="sheet-row">
+              <label>语速</label>
+              <div class="seg-pick">
+                <button
+                  v-for="opt in [
+                    { v: '-40%', label: '慢' },
+                    { v: '-20%', label: '偏慢' },
+                    { v: '+0%',  label: '正常' },
+                    { v: '+20%', label: '偏快' },
+                  ]"
+                  :key="opt.v"
+                  type="button"
+                  :class="{ active: store.speed === opt.v }"
+                  @click="store.speed = opt.v"
+                >{{ opt.label }}</button>
+              </div>
+            </div>
+            <div class="sheet-row">
+              <label>TTS 引擎</label>
+              <div class="seg-pick">
+                <button
+                  v-for="opt in [
+                    { v: 'edge',   label: 'Edge' },
+                    { v: 'doubao', label: '豆包' },
+                  ]"
+                  :key="opt.v"
+                  type="button"
+                  :class="{ active: store.provider === opt.v }"
+                  @click="store.provider = opt.v"
+                >{{ opt.label }}</button>
+              </div>
+            </div>
+
+            <div class="sheet-divider"></div>
+
+            <button
+              v-if="isBbcSource"
+              class="sheet-action"
+              type="button"
+              @click="gotoBbcReview(); onCloseSettings()"
+            >
+              <span class="sa-ico">📖</span>
+              <span class="sa-body">
+                <span class="sa-title">BBC 复习</span>
+                <span class="sa-desc">基于 SRS 的文章复习</span>
+              </span>
+              <span class="sa-chev">›</span>
+            </button>
+            <button
+              class="sheet-action"
+              type="button"
+              @click="onNewImport()"
+            >
+              <span class="sa-ico">🔄</span>
+              <span class="sa-body">
+                <span class="sa-title">重新导入字幕</span>
+                <span class="sa-desc">换一集、换一篇</span>
+              </span>
+              <span class="sa-chev">›</span>
+            </button>
+
+            <div class="sheet-footer-note">
+              ℹ︎ 关于复习评分 · 手机端暂不评分，本次练习不会进入 FSRS 复习计划；
+              如需评分请到桌面端，或关注
+              <a href="https://github.com/bob798/speakeasy/issues/26" target="_blank" rel="noopener">issue #26</a>。
+            </div>
+          </aside>
+        </div>
+      </Transition>
+    </Teleport>
+
+    <ExplanationModal v-model:open="explainOpen" :target="explainTarget" />
+
+    <Transition name="toast">
+      <div v-if="toast.show" class="toast" :class="toast.type">{{ toast.text }}</div>
+    </Transition>
+  </div>
+</template>
+```
+
+- [ ] **Step 3: 改 `<style scoped>` —— 加 mobile 容器 + sheet 样式**
+
+把 `.practice-page` 改为 `100dvh`（替代 `100vh` 防键盘抖动），并追加 sheet / settings-btn 样式：
+
+```css
+.practice-page {
+  display: flex;
+  flex-direction: column;
+  height: 100dvh;            /* 改 100vh → 100dvh */
+  background: var(--bg);
+}
+.practice-page.mobile {
+  /* 手机端：MobileActionDock 是 sticky，列表能滚到底部 */
+}
+
+/* settings-btn（替代 mobile 的 📜 等） */
+.settings-btn {
+  min-width: 44px;
+  height: 36px;
+  padding: 0 12px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  border-radius: 18px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 14px;
+  font-weight: 500;
+  font-family: inherit;
+  border: none;
+  cursor: pointer;
+}
+.settings-btn:focus { outline: none; }
+.settings-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.settings-btn:active { background: var(--accent); color: var(--text-inverse); transform: scale(0.96); }
+
+/* sheet · 底部 */
+.sheet-mask {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.4);
+  z-index: var(--z-modal);
+  display: flex;
+  align-items: flex-end;
+}
+.sheet {
+  width: 100%;
+  background: var(--bg-elevated);
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  padding: var(--space-4);
+  padding-bottom: calc(var(--space-4) + var(--safe-bottom));
+  max-height: 80dvh;
+  overflow-y: auto;
+}
+.sheet h4 { margin: 0 0 var(--space-3); font-size: 14px; color: var(--text-2); }
+.sheet-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 0;
+}
+.sheet-row label { font-size: 14px; color: var(--text-1); }
+.seg-pick { display: flex; gap: 4px; }
+.seg-pick button {
+  padding: 6px 10px;
+  font-size: 12px;
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+  color: var(--text-2);
+  border: 1px solid var(--border);
+  font-family: inherit;
+  cursor: pointer;
+}
+.seg-pick button.active {
+  background: var(--accent); color: #fff; border-color: var(--accent);
+}
+.sheet-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 12px 0;
+}
+.sheet-action {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 10px 8px;
+  border: none;
+  background: transparent;
+  border-radius: var(--radius);
+  cursor: pointer;
+  font-family: inherit;
+  text-align: left;
+  transition: background 120ms var(--ease);
+}
+.sheet-action:active { background: var(--bg); }
+.sheet-action .sa-ico {
+  width: 36px; height: 36px;
+  display: grid; place-items: center;
+  background: var(--accent-soft);
+  color: var(--accent);
+  border-radius: var(--radius-sm);
+  font-size: 18px;
+}
+.sheet-action .sa-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+}
+.sheet-action .sa-title { font-size: 14px; color: var(--text-1); font-weight: 500; }
+.sheet-action .sa-desc { font-size: 11px; color: var(--text-3); }
+.sheet-action .sa-chev { color: var(--text-3); font-size: 18px; }
+.sheet-footer-note {
+  margin-top: 12px;
+  padding: 10px 12px;
+  background: var(--bg);
+  border-radius: var(--radius-sm);
+  font-size: 11px;
+  color: var(--text-3);
+  line-height: 1.5;
+}
+.sheet-footer-note a { color: var(--accent); text-decoration: underline; }
+
+.sheet-enter-active, .sheet-leave-active { transition: opacity 200ms var(--ease); }
+.sheet-enter-active .sheet, .sheet-leave-active .sheet {
+  transition: transform 220ms var(--ease);
+}
+.sheet-enter-from, .sheet-leave-to { opacity: 0; }
+.sheet-enter-from .sheet, .sheet-leave-to .sheet { transform: translateY(100%); }
+```
+
+**注意：** 保留 `.topbar / .layout / .left / .right / .progress / .toast` 等桌面端样式块（原 `Practice.vue` 已有）。只**追加**上述 mobile 相关样式，**删除**以下不再用的旧块：
+- `.mobile-only`、`.desktop-only` 媒体查询切换（现在通过 v-if 切换）
+- `.list-btn`、`.list-drawer*`、`.ld-*`（句子列表抽屉已弃用）
+- 原 `@media (min-width: 768px) { ... }` 块改为：桌面端样式作为默认，手机端用 `.practice-page.mobile` 选择器覆盖
+
+- [ ] **Step 4: Lint check**
+
+Run: `cd frontend && npm run lint -- src/views/Practice.vue`
+Expected: 无 error
+
+- [ ] **Step 5: 启动 dev server 手动验证**
+
+Run: `cd frontend && npm run dev`
+
+打开浏览器 → Practice 页 → Chrome DevTools mobile mode（iPhone 14, 390×844）→ 走核心路径：
+1. 进页面（已导入 BBC 字幕）→ 应弹一次 FSRS toast，再 reload 不再弹
+2. 当前句居中、其它句紧凑
+3. 点当前句某词 → 下划线高亮 + 「已选: xxx」条 + dock 主标签变「解释单词」/「发音单词」+ coach bar 显示「解读 "xxx"」
+4. ✕ 清除选词 → 主标签回「解释整句」
+5. 切到 DevTools 桌面尺寸（1280px）→ 回原桌面端布局 → 切回 mobile 不报错
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/views/Practice.vue
+git commit -m "feat(practice): wire mobile redesign into Practice.vue"
+```
+
+---
+
+## Phase 5 · sheet a11y 收尾
+
+### Task 6: sheet 焦点管理 + 背景 inert
+
+**Files:**
+- Modify: `frontend/src/views/Practice.vue`
+
+- [ ] **Step 1: 加 sheet 打开/关闭的焦点管理**
+
+在 `<script setup>` 适当位置（接近 `onOpenSettings`/`onCloseSettings`）替换为：
+
+```js
+const sheetTriggerRef = ref(null) // 记录打开 sheet 时的触发元素
+const sheetRef = ref(null)        // <aside class="sheet"> dom ref
+
+function onOpenSettings() {
+  sheetTriggerRef.value = document.activeElement
+  sheetOpen.value = true
+  // 等下一帧 DOM 出现再 focus
+  setTimeout(() => {
+    const first = sheetRef.value?.querySelector('button')
+    if (first) first.focus()
+  }, 60)
+  // 屏蔽背景 a11y
+  document.querySelectorAll('.topbar, .m-list, .dock, .layout').forEach((el) => el.setAttribute('inert', ''))
+}
+function onCloseSettings() {
+  sheetOpen.value = false
+  document.querySelectorAll('.topbar, .m-list, .dock, .layout').forEach((el) => el.removeAttribute('inert'))
+  if (sheetTriggerRef.value?.focus) sheetTriggerRef.value.focus()
+}
+```
+
+并在模板的 `<aside class="sheet" ...>` 上加 `ref="sheetRef"`。
+
+- [ ] **Step 2: 加全局 Esc 监听（仅 sheet 打开时生效）**
+
+在 script 末尾加：
+
+```js
+function _onEscape(e) {
+  if (e.key === 'Escape' && sheetOpen.value) onCloseSettings()
+}
+window.addEventListener('keydown', _onEscape)
+onBeforeUnmount(() => window.removeEventListener('keydown', _onEscape))
+```
+
+- [ ] **Step 3: 手动验证**
+
+Run: `cd frontend && npm run dev`，在 mobile mode 测：
+- Tab 进 ⚙ 按钮 → Enter → sheet 打开，焦点落到第一个按钮（语速「慢」）
+- 按 Esc → sheet 关，焦点回到 ⚙ 按钮
+- Voice Over 或 Chrome a11y inspector 看背景区是否被 `inert` 屏蔽（语速 sheet 外的 list / dock 应不可达）
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/views/Practice.vue
+git commit -m "feat(practice): sheet focus management + Esc + inert background"
+```
+
+---
+
+## Phase 6 · 视觉 / 边界 / 回归
+
+### Task 7: 长句 / 横屏 / 跨断点回归
+
+**Files:**
+- Verify only
+
+- [ ] **Step 1: 长句压力测试**
+
+在 Practice 页 import 一段含超长 token 的字幕（手动改 subtitle text 加 `pneumonoultramicroscopicsilicovolcanoconiosis` 之类）。
+验证：当前句卡不撑炸，按词渲染正常断词，dock 不被推出屏外。
+
+- [ ] **Step 2: 横屏测试**
+
+DevTools 切 iPhone 14 横屏（844×390）→ 验证：
+- coach bar 隐藏
+- dock 两行按钮压成 44px 高
+- 句子列表正常滚动
+
+- [ ] **Step 3: 跨断点测试**
+
+打开 Practice 页 mobile mode（390 宽）→ 点开 ⚙ sheet → 在 DevTools 把宽度拖到 1280 → 验证：
+- sheet 自动关
+- selectedWord 自动清
+- 没有 ResizeObserver / matchMedia 报错
+- 反向（1280 → 390）也无报错
+
+- [ ] **Step 4: 录音中切句 confirm**
+
+mobile mode → 点 🎤 录音 → 在录音过程中点列表里另一句 → 应弹 `window.confirm` 提示「正在录音，停止并切换到这一句？」
+- 取消 → 留在当前句、继续录
+- 确定 → 录音停止 + 切到新句 + 录音 blob discard
+
+- [ ] **Step 5: 异步 stale 响应**
+
+在 DevTools Network 面板设 Slow 3G → 选词 → 快速切到别句 → 切回 → 验证：旧请求回来不会触发任何 UI 变化（用 console.log 在 `_lastRequestKey !== key` 分支临时加日志验证一次后撤）。
+
+- [ ] **Step 6: 提交（如有 fix）**
+
+如果上述任何一步发现 bug 修了，按 fix 类型 commit：
+
+```bash
+git add -p
+git commit -m "fix(practice): <具体描述>"
+```
+
+否则跳过此步。
+
+---
+
+### Task 8: Bundle size 校验
+
+**Files:**
+- Verify only
+
+- [ ] **Step 1: 构建生产包**
+
+Run: `cd frontend && npm run build`
+Expected: 构建成功，无 error
+
+- [ ] **Step 2: 检查 size budget**
+
+Run: `cd frontend && npm run size`
+Expected: 各项均在 budget 内（200KB JS gzip / 100KB CSS gzip 见 package.json size-limit 配置）
+
+如超：检查是否引入了不必要的新依赖；本次只新增 composable + 2 个 Vue 组件，理论上增量 < 5KB gzip。
+
+- [ ] **Step 3: 跑全套 unit tests**
+
+Run: `cd frontend && npm test`
+Expected: 全过（含新增 useCoachBar.spec.js）
+
+- [ ] **Step 4: 后端 pytest 回归（防意外动到 API）**
+
+```bash
+source venv/bin/activate
+pytest tests/ -v
+```
+Expected: 全过（本次不动后端，应该零变化）
+
+- [ ] **Step 5: Commit（如有调整）**
+
+如 budget 不达调整后 commit，否则跳过。
+
+---
+
+## Phase 7 · PR
+
+### Task 9: 推分支 + 开 PR
+
+**Files:**
+- N/A
+
+- [ ] **Step 1: 检查分支状态**
+
+Run: `git log --oneline main..feat/practice-mobile-redesign`
+Expected: 看到 spec commit + 7-8 个实现 commit
+
+- [ ] **Step 2: 推到远程**
+
+Run: `git push -u origin feat/practice-mobile-redesign`
+
+- [ ] **Step 3: 开 PR**
+
+```bash
+gh pr create --title "feat(practice): 手机端重设计 · 单作用对象 + coach bar + 底部 dock" --body "$(cat <<'EOF'
+## Summary
+
+把 Practice 发音练习页手机端 (`<768px`) 改造为「单手大拇指可达 + 教练状态条引导」的练习页。桌面端不变。
+
+设计文档：`docs/superpowers/specs/2026-05-12-practice-mobile-redesign.md`
+原型：`mockups/practice-mobile-v2.html`
+
+主要变化：
+- 删除 📜 句子列表抽屉，列表直接在主页面滚
+- dock 两行四按钮：💡 解释 / 🔊 发音 / 🎤 录音 / ▶ 回放
+- dock 主标签随选词模式切换：默认 `解释整句`，选词后变 `解释单词`
+- 新增 coach bar：引导 + 进度 + 反馈一行（v1 静态规则推导，v2 接 LLM）
+- 顶栏只留 ⚙ 设置（语速 / 引擎 / 📖 BBC / 🔄 重新导入 / ℹ︎ FSRS 说明）
+- 手机端暂无评分入口（issue #26 跟进）；首次进 Practice 弹一次 FSRS 披露 toast
+
+## Test plan
+
+- [ ] iPhone 14 模拟器：💡/🔊/🎤/▶/⚙ 单手可达
+- [ ] 选词后 dock 主标签 + coach bar 同步变化
+- [ ] 切句清选词，录音中切句弹 confirm
+- [ ] 首次 toast + ⚙ 内 ℹ︎ 行都在
+- [ ] 横屏 dock 压成单行，coach bar 隐藏
+- [ ] 长句不撑炸卡片
+- [ ] 跨断点（767 ↔ 768）resize 不残留 / 不报错
+- [ ] 桌面端 ≥ 768px 布局不变
+- [ ] `npm test` 全过（含新 useCoachBar.spec.js）
+- [ ] `npm run size` 在 budget 内
+- [ ] `npm run build` 成功
+
+Closes 暂无（issue #26 后续处理评分）
+EOF
+)"

--- a/docs/superpowers/specs/2026-05-12-practice-mobile-redesign.md
+++ b/docs/superpowers/specs/2026-05-12-practice-mobile-redesign.md
@@ -1,0 +1,191 @@
+# Practice 手机端重设计
+
+> Date: 2026-05-12
+> Owner: Claude Code (实现) · Human (验收)
+> 范围: 仅手机端 (`<768px`) Practice 页布局与交互；桌面端保持现状
+> 原型: `mockups/practice-mobile-v2.html`
+> 关联 issue: #26（手机端评分流后续重做）
+
+## 目标
+
+让用户在手机上用「单手 + 大拇指」就能完成一次完整的发音练习单循环（听原音 → 看解释 → 录音 → 回放），常用动作不需要滚屏才能找到。
+
+## 现状问题
+
+当前手机端 `Practice.vue` 沿用桌面端 PracticePlayer 的单栏堆叠：句子 → 解释按钮 → 词条/输入 → 语速/引擎下拉 → 播音/录音/回放 → 评分。所有控件挂在一条可滚动的列里，常用按钮（解释 / 发音 / 录音）随屏幕大小不同被推到看不见的位置。`📜` 抽屉是补丁，没解决主页面臃肿。
+
+## 设计
+
+### 布局骨架
+
+```
+┌─────────────────────────────────────┐
+│ ← 返回   发音练习            ⚙ 设置 │ 顶栏 56px (sticky)
+├─────────────────────────────────────┤
+│ 1  Welcome to BBC English at Work.. │
+│                                     │
+│ 2 ▶ Could you give me the           │ 当前句卡（高亮）
+│    ─schedule─ for tomorrow.         │ 单词可点；选中 = 下划线 + 底色
+│    ⭕ 已选: schedule          ✕    │ 选中条仅在选词时出现
+│                                     │
+│ 3  Sure, you have a meeting at...   │
+│ 4  ...                              │ 整页可垂直滚动
+│ ...                                 │ tap 任意句 = 切为当前句
+│                                     │
+├──── dock (sticky 底部，2 行) ───────┤
+│  💡 解释 [整句]    🔊 发音 [整句]   │ 副标题随选中状态变化
+│  🎤 录音 [开始录]   ▶ 回放 [无录音] │ 录音中变红 + 脉冲
+└─────────────────────────────────────┘
+```
+
+### 单一作用对象模型
+
+- **作用对象**：当前句（默认）∪ 当前句里的某个选中词
+- 💡 解释 / 🔊 发音 永远作用在「当前作用对象」上
+- 按钮**副标题显式标注**当前作用对象：
+  - 未选词：副标题 = `整句`
+  - 选中词：副标题 = `<word>`（例如 `schedule`）
+- 切换当前句 / 再点同词 / 点选中条的 ✕ → 取消选词
+
+### 顶栏
+
+- 左：`← 返回`
+- 中：标题「发音练习」
+- 右：单一胶囊按钮 `⚙ 设置`（背景 `--accent-soft`，强调可点）
+- **删除**：原 `📜 句子列表`（列表直接在身体区）
+- **删除**：原 `🔄 重新导入` 顶栏入口（收进 ⚙ sheet）
+- **删除**：原 `📖 BBC 复习` 顶栏入口（收进 ⚙ sheet，仅 BBC 源时显示）
+
+### 句子列表
+
+- 整页一栏，垂直滚动，进页面/切句时 `scrollIntoView({block:'center'})`
+- 每条卡：`<序号> <文本>`，tap 整行 = 切为当前句
+- **当前句视觉差异**：
+  - 左侧 3px `--accent` 色条
+  - 背景 `--bg-elevated` + 轻阴影
+  - 文本字号 18px / 加粗，相比非当前 15px / `--text-2`
+  - 单词可点（拆词 + 标点保留）
+  - 选中词条仅当前句显示
+- 不显示 FSRS 状态点（issue #26 评分流重做后再考虑加回）
+
+### 单词选择
+
+- 仅当前句的单词渲染为 `<button class="word">`
+- 拆词正则 `[A-Za-z][A-Za-z'-]*`，标点 / 空白作为文本节点保留
+- 选中样式：`text-decoration: underline 2px var(--accent); background: var(--accent-soft); color: var(--accent)`
+- 选中条样式：`background: var(--accent-soft)`，左侧⭕图标 + 已选词加粗，右侧 ✕ 按钮
+- 切换当前句时自动清除选词
+
+### Dock
+
+- `position: sticky; bottom: 0`，`backdrop-filter: blur(20px) saturate(180%)`
+- 两行四按钮，每按钮 minHeight 56px，flex: 1 等分宽
+- **上行（accent 实色）**：
+  - 💡 解释：副标题动态 = `整句` / 选中词
+  - 🔊 发音：副标题动态 = `整句` / 选中词
+- **下行（白底）**：
+  - 🎤 录音：副标题 = `开始录` / 录音中 `录音中…` / 录过 `重录`；录音中按钮变红 + `rec-pulse` 动画
+  - ▶ 回放：副标题 = `无录音` / `听自己`；无录音时 `opacity: 0.45`，点击 toast 提示「先录一段」
+- 评分按钮 ❌ 暂不放（issue #26 跟进）
+- `padding-bottom` 含 `env(safe-area-inset-bottom)` 适配 iOS
+
+### ⚙ 设置 sheet
+
+从底部上滑，最大高度内容自适应：
+
+```
+┌── 设置 ─────────────────┐
+│ 语速  [慢][偏慢][正常][偏快] │
+│ 引擎  [Edge][豆包][Azure]  │
+├──────────────────────┤
+│ 📖 BBC 复习            > │ ← 仅 BBC EAW 源显示
+│    基于 SRS 的文章复习    │
+│ 🔄 重新导入字幕         > │
+│    换一集、换一篇         │
+└──────────────────────┘
+```
+
+- 语速 / 引擎 用分段控制器（segment picker）而非 select 下拉
+- 操作行带图标 + 描述 + chevron，tap 后关 sheet 并执行
+- 选中分段实色 accent 背景
+
+### 行为细节
+
+| 触发 | 行为 |
+|---|---|
+| 进页面 | 自动滚到 `currentIdx` 句，居中 |
+| tap 非当前句 | 切当前句 → 清除选词 → 滚到中央 |
+| tap 当前句的词 | 选中（再点同词 = 取消） |
+| tap ✕ 选中条 / 切句 | 清除选词 |
+| tap 💡 解释 | 调用 `/practice/explain/stream`，内容 = 整句 or 选中词 |
+| tap 🔊 发音 整句 | 调用 `POST /practice/tts`（已有，沿用 `ttsBlob`） |
+| tap 🔊 发音 选中词 | 调用 `POST /practice/explain/phonetic` 拿 IPA + 朗读单词（短 TTS 复用同一 `POST /practice/tts`） |
+| tap 🎤 录音 | 启动 MediaRecorder；再 tap = 停止 |
+| tap ▶ 回放 | 播放本地录音 blob |
+| tap ⚙ | 打开 sheet |
+| sheet 内选语速/引擎 | 更新 store，下次 TTS 生效 |
+| sheet 内点 📖 | router push `bbc-review/<slug>` |
+| sheet 内点 🔄 | 重置 store，回到 SubtitleImport 视图 |
+
+### 视觉规范
+
+- 沿用全站 design tokens：`--accent: #3d6b4f`、`--bg-elevated`、`--radius` 等
+- 不引入「pencil 草图风」—— Practice 是高频操作页，规整视觉的长时间使用舒适度优于风格化
+
+## 组件拆分
+
+```
+Practice.vue                         <- 容器：路由 + store + ⚙ sheet 状态
+├─ SubtitleImport.vue                <- 不动（hasSource = false 时）
+├─ MobileSentenceList.vue (新)       <- 列表渲染 + 切句
+│  └─ MobileCurrentSentence.vue (新) <- 当前句卡：词拆分 + 选词 + 选中条
+├─ MobileDock.vue (新)               <- 4 按钮 + 副标题状态机
+└─ MobileSettingsSheet.vue (新)      <- ⚙ sheet：语速/引擎/📖/🔄
+
+桌面端 (`>= 768px`) 仍走老的 SentenceList + PracticePlayer 双栏。
+通过 CSS `@media` + 容器组件根据宽度切换子组件即可，不复制业务逻辑。
+```
+
+### 共用 composables（已有，不动）
+
+- `usePracticeStore` — currentSource / segments / currentIdx / cards / speed / provider
+- `usePractice` — createCards / ttsBlob / rateCard
+- `useRecorder` — MediaRecorder 包装
+- `useAuthFetch` — 认证 + 错误处理
+
+### 新增 store 字段
+
+- `selectedWord: string | null` — 当前选中词；切句时自动清零
+
+## 测试策略
+
+手动用 Chrome DevTools mobile mode（iPhone 14 / 390×844、Pixel 5 / 393×851）验证：
+
+1. **核心路径**：导入 BBC → 进入页面 → 当前句居中 → 点 💡 → ExplanationModal 打开（mock 数据时检查副标题为 `整句`）
+2. **选词路径**：点当前句某词 → 下划线高亮 → 选中条出现 → 💡 副标题变为 `<word>` → 点 💡 → 调用带 word 参数
+3. **切句**：点列表里其它句 → 该句变当前 → 选词清零 → 滚到中央
+4. **录音闭环**：点 🎤 → 红色脉冲 → 点停止 → ▶ 回放从 disabled 变可点
+5. **⚙ sheet**：点 ⚙ → 从底部滑出 → 改语速 → 关 sheet → 下次 🔊 用新语速
+6. **safe-area**：在 iOS 模拟器看 dock 距底部 home indicator 有间距，顶栏距状态栏有间距
+7. **回归**：宽屏（>=768px）切回桌面端布局，原有行为不变
+
+不增加自动化测试（UI 重组、无新业务逻辑）；e2e 由人工走核心路径完成。
+
+## Out of Scope
+
+- **手机端评分**（issue #26）：暂不做，FSRS 状态读不写
+- **桌面端布局调整**：本次不动
+- **滑动手势切句**：未来增强，本次只支持 tap
+- **长按词预览音标**：未来增强
+- **进度条 / 已练 N/M 统计**：暂不显示在手机顶栏（可由 ⚙ sheet 中点 📖 跳过去看）
+- **暗色模式**：tokens.css 已留钩子，本次不实装
+
+## 验收标准
+
+- [ ] iPhone 14 模拟器单手操作，所有常用动作（💡/🔊/🎤/▶/⚙）拇指可达
+- [ ] 切换当前句时选词正确清零
+- [ ] dock 副标题随选词状态变化
+- [ ] ⚙ sheet 内的语速/引擎修改影响下次 🔊 发音
+- [ ] 旧路径（导入字幕、ExplanationModal 联动）不破
+- [ ] 桌面端布局不变
+- [ ] frontend bundle 增量 < 30KB gzip（无新大依赖）

--- a/docs/superpowers/specs/2026-05-12-practice-mobile-redesign.md
+++ b/docs/superpowers/specs/2026-05-12-practice-mobile-redesign.md
@@ -8,7 +8,9 @@
 
 ## 目标
 
-让用户在手机上用「单手 + 大拇指」就能完成一次完整的发音练习单循环（听原音 → 看解释 → 录音 → 回放），常用动作不需要滚屏才能找到。
+**主目标**：让用户在手机上用「单手 + 大拇指」就能完成一次完整的发音练习单循环（听原音 → 看解释 → 录音 → 回放），常用动作不需要滚屏才能找到。
+
+**次目标（私教感）**：让用户明确知道**自己正在练哪一句、刚完成了什么、下一步该做什么**。Practice 是 Speakeasy「AI 陪伴式私教」的一个肢体，不是孤立的工具页 —— 它必须有引导感、反馈感、进度感。
 
 ## 现状问题
 
@@ -32,8 +34,10 @@
 │ 4  ...                              │ 整页可垂直滚动
 │ ...                                 │ tap 任意句 = 切为当前句
 │                                     │
+├──── coach bar ─────────────────────┤
+│ 🎯 第 3/12 句 · 先听我读一次          │ 状态条（引导 + 进度）
 ├──── dock (sticky 底部，2 行) ───────┤
-│  💡 解释 [整句]    🔊 发音 [整句]   │ 副标题随选中状态变化
+│  💡 解释整句         🔊 发音整句     │ 主标签随选中状态变化
 │  🎤 录音 [开始录]   ▶ 回放 [无录音] │ 录音中变红 + 脉冲
 └─────────────────────────────────────┘
 ```
@@ -42,9 +46,15 @@
 
 - **作用对象**：当前句（默认）∪ 当前句里的某个选中词
 - 💡 解释 / 🔊 发音 永远作用在「当前作用对象」上
-- 按钮**副标题显式标注**当前作用对象：
-  - 未选词：副标题 = `整句`
-  - 选中词：副标题 = `<word>`（例如 `schedule`）
+- **主标签** + 副标签**双层显式**标注当前作用对象，避免模式只藏在副标题里：
+
+  | 状态 | 💡 主标签 | 💡 副标签 | 🔊 主标签 | 🔊 副标签 |
+  |---|---|---|---|---|
+  | 未选词 | `解释整句` | — | `发音整句` | — |
+  | 选中 `schedule` | `解释单词` | `schedule` | `发音单词` | `schedule` |
+
+  主标签层级（句/词）变化让用户一眼分清当前模式，副标签补充具体词面，**两条信息互不冗余**。
+
 - 切换当前句 / 再点同词 / 点选中条的 ✕ → 取消选词
 
 ### 顶栏
@@ -76,18 +86,48 @@
 - 选中条样式：`background: var(--accent-soft)`，左侧⭕图标 + 已选词加粗，右侧 ✕ 按钮
 - 切换当前句时自动清除选词
 
-### Dock
+### Dock (`MobileActionDock.vue`)
 
 - `position: sticky; bottom: 0`，`backdrop-filter: blur(20px) saturate(180%)`
 - 两行四按钮，每按钮 minHeight 56px，flex: 1 等分宽
 - **上行（accent 实色）**：
-  - 💡 解释：副标题动态 = `整句` / 选中词
-  - 🔊 发音：副标题动态 = `整句` / 选中词
+  - 💡 主标签：`解释整句` / `解释单词`；副标签：选词时显示词面
+  - 🔊 主标签：`发音整句` / `发音单词`；副标签：选词时显示词面
 - **下行（白底）**：
   - 🎤 录音：副标题 = `开始录` / 录音中 `录音中…` / 录过 `重录`；录音中按钮变红 + `rec-pulse` 动画
-  - ▶ 回放：副标题 = `无录音` / `听自己`；无录音时 `opacity: 0.45`，点击 toast 提示「先录一段」
+  - ▶ 回放：副标题 = `无录音` / `听自己`；无录音时视觉灰化但**仍可点**，通过 `aria-disabled="true"` 表达语义，点击 toast 提示「先录一段」
 - 评分按钮 ❌ 暂不放（issue #26 跟进）
 - `padding-bottom` 含 `env(safe-area-inset-bottom)` 适配 iOS
+- **该 dock 是可复用容器模式**：仅承载 `2×2 主动作栅格 + coach bar 槽 + safe-area`，将来 Translate / Polish 出现高频底部动作时可沿用同一壳层（届时把组件名提升至 `frontend/src/components/common/`）
+
+### 教练状态条 Coach Bar（dock 顶部，第一行）
+
+一行轻量文本，**同时承担引导 / 反馈 / 进度感**。位置在 dock 内部最顶（在两行按钮之上），不再占用主操作区空间。
+
+**v1 静态规则（不接 LLM，由前端状态推导）**：
+
+| 状态 | 文案 |
+|---|---|
+| 进入页面 / 切句 / 无录音 / 无选词 | `🎯 第 N/M 句 · 先听我读一次` |
+| 选中词时 | `🎯 第 N/M 句 · 解读 "<word>"` |
+| TTS 播放中 | `🔊 听着…` |
+| 录音中 | `🎤 录音中 · 念完点停止` |
+| 录完未回放 | `✅ 收到了 · 回放听听自己` |
+| 录完已回放 | `👍 比一比，节奏对齐了吗` |
+| 第 1 句完成（无评分仍切到下一句） | `不错，已经顺下来 1 句了` |
+| 第 5/10/N 句节点 | `👏 连续 N 句` |
+
+**样式**：`padding: 8px var(--space-4); font-size: 12px; color: var(--text-2); background: var(--bg-elevated); border-top: 1px solid var(--border); display: flex; align-items: center; gap: 8px`。
+
+**v2（未来）**：把 「TTS 播完」「录完节奏对齐评估」等接 LLM 微文案（短句、≤ 20 字），保持 1 行不变。本次 spec 不实施。
+
+### FSRS 闭环缺口披露（非常驻）
+
+由于本次手机端无评分入口，FSRS 卡的 due / stability 不会被更新。**披露策略**（**不**占主操作区）：
+
+1. **首次进入提示**：用户首次进入 Practice 页时弹一次 toast（持续 4s）：「手机端暂不记录复习评分，仍可正常练习」。dismiss 后写 `localStorage['v2:practice.fsrs_notice_seen'] = 1`，不再弹。
+2. **⚙ sheet 内常态说明**：sheet 底部加一条 disabled-looking 行 `ℹ︎ 关于复习评分`，描述当前为「只读 FSRS」状态，并 link to issue #26。
+3. **issue #26 退出条件**：mobile 恢复至少 Again/Good 两档评分入口前，上述两处披露**不得删**。
 
 ### ⚙ 设置 sheet
 
@@ -127,23 +167,53 @@
 | sheet 内点 📖 | router push `bbc-review/<slug>` |
 | sheet 内点 🔄 | 重置 store，回到 SubtitleImport 视图 |
 
+### 状态机约束（真机必要）
+
+1. **切句前的清理**：tap 非当前句 → 依序执行 `stopTTS()` → `clearSelectedWord()` → 切 `currentIdx` → 滚到中央。**录音中切句**不静默切，弹 native `confirm` 或自定义 sheet：「正在录音，停止并切句？/ 留在当前句」。
+2. **录音绑定句子**：录音启动时记录 `recordingSegIdx = currentIdx`；停止前 `currentIdx` 必须 == `recordingSegIdx`，否则视为异常并丢弃 blob。
+3. **异步响应去重**：每次 💡/🔊 请求生成 `requestKey = currentIdx + ':' + (selectedWord || '__sentence__') + ':' + Date.now()`；响应回来比对最新 key，不匹配则 silently drop 不渲染、不播音。
+4. **TTS 并发**：新 TTS 请求触发时，先 `_releaseTTS()` 释放上一段 audio + objectURL，再起新 audio。
+5. **选词清理**：切句 / 同词再点 / ✕ / `isMobile` watch 翻转（窗口缩放跨 768px 断点） → 全部清 `selectedWord`。
+
 ### 视觉规范
 
 - 沿用全站 design tokens：`--accent: #3d6b4f`、`--bg-elevated`、`--radius` 等
 - 不引入「pencil 草图风」—— Practice 是高频操作页，规整视觉的长时间使用舒适度优于风格化
 
+### 可访问性（a11y）规范
+
+1. **真实按钮语义**：句中的可点词渲染为 `<button class="word">`，**不允许**用 `<span>` + `onclick`。键盘 Enter/Space 可触发；选中态用 `aria-pressed="true"`。
+2. **焦点环不剥离**：禁用全局 `button:focus { outline: none }`。改用 `:focus-visible` 定义自有 2px accent outline，键盘导航可见、触控点击不可见。
+3. **真 disabled vs aria-disabled**：dock 的「▶ 回放」无录音时**不要**用 `disabled` 属性（会丢失 tabindex、读屏跳过）。改用 `aria-disabled="true"` + 视觉灰化，仍可点出 toast 提示。
+4. **dock 按钮 aria-label**：动态描述当前作用对象，例如 `aria-label="解释，当前作用对象：schedule"` / `aria-label="发音整句"`。`<button>` 内部图标用 `aria-hidden="true"`。
+5. **sheet focus 管理**：⚙ sheet 打开时初始焦点落到首个交互项；用 `inert` 属性把背景区屏蔽出无障碍树；关闭时焦点还给「⚙ 设置」按钮。
+6. **录音状态可读**：录音中给按钮加 `aria-pressed="true"`；副标题文本 `录音中…` 包裹 `aria-live="polite"` 让读屏读出。
+7. **触控目标**：dock 按钮 ≥ 56×56pt；句中词 button 高度 ≥ 28pt（行内紧凑容许，但通过 `padding` 保证可点）。
+
+### Mobile edge cases（必处理）
+
+| 场景 | 处理 |
+|---|---|
+| **长句 / 超长 token** | 句子文本加 `overflow-wrap: anywhere; word-break: break-word; hyphens: auto`；卡片不撑炸 |
+| **横屏（max-height: 500px）** | dock 压成单行 4 按钮；句子卡高度自适应；隐藏 FSRS 提示文案 |
+| **软键盘弹起 / Safari 动态 viewport** | 容器高度用 `100dvh`（非 `100vh`）；dock 用 `sticky` + 父容器滚动而非 `fixed`，键盘弹起时不会遮挡；本次 mobile 无输入框，键盘路径仅可能从外部 paste/语音输入触发，仍要 `dvh` 兜底 |
+| **快速连续点词** | 副标题 / 选中条 / explain target 由同一 ref 派生，render 一致；prevent 双击放大 `touch-action: manipulation` |
+| **录音中切句 / 切词** | 状态机约束 #1 + #2 强制 confirm + 丢弃异常 blob |
+| **窗口缩放跨 768px 断点** | `watch(isMobile)` 触发清理：清选词、关 sheet、停 TTS、停录音 |
+
 ## 组件拆分
 
 ```
-Practice.vue                         <- 容器：路由 + store + ⚙ sheet 状态
-├─ SubtitleImport.vue                <- 不动（hasSource = false 时）
-├─ MobileSentenceList.vue (新)       <- 列表渲染 + 切句
-│  └─ MobileCurrentSentence.vue (新) <- 当前句卡：词拆分 + 选词 + 选中条
-├─ MobileDock.vue (新)               <- 4 按钮 + 副标题状态机
-└─ MobileSettingsSheet.vue (新)      <- ⚙ sheet：语速/引擎/📖/🔄
+Practice.vue                          <- 容器：路由 + store + 本地 selectedWord/sheetOpen + ⚙ sheet + 首次 FSRS toast
+├─ SubtitleImport.vue                 <- 不动（hasSource = false 时）
+├─ MobileSentenceList.vue (新)        <- 列表 + 当前句卡（含词拆分 + 选词 + 选中条），通过 props 接 selectedWord
+└─ MobileActionDock.vue (新)          <- coach bar + 4 按钮 + 主/副标签状态机
+                                         · 命名中性，未来 Translate/Polish 可复用同一壳层
+                                         · 若复用真发生，移到 components/common/
 
 桌面端 (`>= 768px`) 仍走老的 SentenceList + PracticePlayer 双栏。
 通过 CSS `@media` + 容器组件根据宽度切换子组件即可，不复制业务逻辑。
+⚙ sheet 直接写在 Practice.vue 内（modal 性质，没必要早拆）；底部 sheet 公共组件等多页面共用时再抽。
 ```
 
 ### 共用 composables（已有，不动）
@@ -153,9 +223,9 @@ Practice.vue                         <- 容器：路由 + store + ⚙ sheet 状�
 - `useRecorder` — MediaRecorder 包装
 - `useAuthFetch` — 认证 + 错误处理
 
-### 新增 store 字段
+### 本地状态（不入 Pinia）
 
-- `selectedWord: string | null` — 当前选中词；切句时自动清零
+`selectedWord` 是纯瞬时 UI 状态，仅服务 mobile 视图，**不放进 `practiceStore`**（store 跨视图持久化会污染桌面端 / 跨断点切换）。改放在 `Practice.vue` 的 `ref`，通过 props/emit 传给 `MobileSentenceList` 和 `MobileDock`。同样地，`sheetOpen` / `recordingSegIdx` 也保持本地。
 
 ## 测试策略
 
@@ -164,28 +234,44 @@ Practice.vue                         <- 容器：路由 + store + ⚙ sheet 状�
 1. **核心路径**：导入 BBC → 进入页面 → 当前句居中 → 点 💡 → ExplanationModal 打开（mock 数据时检查副标题为 `整句`）
 2. **选词路径**：点当前句某词 → 下划线高亮 → 选中条出现 → 💡 副标题变为 `<word>` → 点 💡 → 调用带 word 参数
 3. **切句**：点列表里其它句 → 该句变当前 → 选词清零 → 滚到中央
-4. **录音闭环**：点 🎤 → 红色脉冲 → 点停止 → ▶ 回放从 disabled 变可点
+4. **录音闭环**：点 🎤 → 红色脉冲 → 点停止 → ▶ 回放从灰化变可点
 5. **⚙ sheet**：点 ⚙ → 从底部滑出 → 改语速 → 关 sheet → 下次 🔊 用新语速
 6. **safe-area**：在 iOS 模拟器看 dock 距底部 home indicator 有间距，顶栏距状态栏有间距
 7. **回归**：宽屏（>=768px）切回桌面端布局，原有行为不变
+8. **录音中切句**：录音中点其它句 → 必须弹 confirm，「停止并切句」起作用、「留在当前句」起作用
+9. **横屏**：844×390 / 851×393 → dock 压成单行 4 按钮 / 句子卡正常，无内容被遮挡
+10. **可访问性 · 键盘**：Tab/Shift+Tab 焦点顺序合理；句中词 Enter/Space 可选中；sheet 打开后 Tab 在 sheet 内循环
+11. **可访问性 · 读屏**：VoiceOver/TalkBack 朗读 dock 按钮时报出当前作用对象（如「解释，当前作用对象：schedule」）；录音中读出「录音中」状态
+12. **并发场景**：同一句内快速连点 5 个不同词，最终副标题 / 选中条 / explain target 一致；录音中 phonetic API 慢响应回来不会播旧词
 
 不增加自动化测试（UI 重组、无新业务逻辑）；e2e 由人工走核心路径完成。
 
 ## Out of Scope
 
 - **手机端评分**（issue #26）：暂不做，FSRS 状态读不写
+  - 硬约束：在 #26 完成、至少 Again/Good 两档评分入口恢复前，**首次进入 FSRS toast** + **⚙ sheet 内 ℹ︎ 关于复习评分**两处披露**不得移除**
 - **桌面端布局调整**：本次不动
 - **滑动手势切句**：未来增强，本次只支持 tap
 - **长按词预览音标**：未来增强
-- **进度条 / 已练 N/M 统计**：暂不显示在手机顶栏（可由 ⚙ sheet 中点 📖 跳过去看）
+- **LLM 微文案 coach bar**（v2）：本次 v1 用静态规则推导，不接 LLM
+- **进度条 / 已练 N/M 单独行**：进度信息**已**融进 coach bar，不再单独占行
 - **暗色模式**：tokens.css 已留钩子，本次不实装
 
 ## 验收标准
 
 - [ ] iPhone 14 模拟器单手操作，所有常用动作（💡/🔊/🎤/▶/⚙）拇指可达
 - [ ] 切换当前句时选词正确清零
-- [ ] dock 副标题随选词状态变化
+- [ ] dock 主标签随选词状态切换（句↔词），副标签显示具体词面
+- [ ] coach bar 文案随状态推导（空闲/听/录/回放/切句）正确变化
+- [ ] coach bar 始终展示「第 N/M 句」进度
+- [ ] 首次进入 Practice 弹一次 FSRS toast，再次进入不弹
+- [ ] ⚙ sheet 底部存在「ℹ︎ 关于复习评分」常态说明行
 - [ ] ⚙ sheet 内的语速/引擎修改影响下次 🔊 发音
+- [ ] 录音中切句弹 confirm，不静默切
+- [ ] 异步 stale 响应被丢弃（手动模拟慢网测试）
+- [ ] 横屏 dock 布局正常（coach bar 可隐藏以省高度）
+- [ ] 句中词为真 `<button>`，键盘 Enter/Space 可选中
+- [ ] `:focus-visible` 焦点环可见
 - [ ] 旧路径（导入字幕、ExplanationModal 联动）不破
 - [ ] 桌面端布局不变
 - [ ] frontend bundle 增量 < 30KB gzip（无新大依赖）

--- a/frontend/src/components/practice/MobileActionDock.vue
+++ b/frontend/src/components/practice/MobileActionDock.vue
@@ -1,0 +1,189 @@
+<script setup>
+/**
+ * MobileActionDock · 手机端底部 action dock
+ *
+ * 仅 UI 与 props/emit；所有副作用在 Practice.vue。
+ * 设计文档：docs/superpowers/specs/2026-05-12-practice-mobile-redesign.md
+ *
+ * 该 dock 是可复用容器模式：未来 Translate / Polish 出现高频底部动作可沿用。
+ */
+import { computed } from 'vue'
+import { useCoachBar } from '@/composables/useCoachBar'
+
+const props = defineProps({
+  selectedWord:   { type: Object, default: null },
+  recording:      { type: Boolean, default: false },
+  isPlayingTTS:   { type: Boolean, default: false },
+  hasRecording:   { type: Boolean, default: false },
+  hasPlayedBack:  { type: Boolean, default: false },
+  currentIdx:     { type: Number, default: 0 },
+  totalSegments:  { type: Number, default: 0 },
+  practicedCount: { type: Number, default: 0 },
+})
+
+const emit = defineEmits(['explain', 'speak', 'toggle-record', 'playback'])
+
+// 把 props 转 refs 喂 useCoachBar
+const state = {
+  selectedWord:   computed(() => props.selectedWord),
+  recording:      computed(() => props.recording),
+  isPlayingTTS:   computed(() => props.isPlayingTTS),
+  hasRecording:   computed(() => props.hasRecording),
+  hasPlayedBack:  computed(() => props.hasPlayedBack),
+  currentIdx:     computed(() => props.currentIdx),
+  totalSegments:  computed(() => props.totalSegments),
+  practicedCount: computed(() => props.practicedCount),
+}
+const { coachCopy, coachClass, coachProgress } = useCoachBar(state)
+
+// 主标签：句模式 vs 词模式
+const explainLabel = computed(() => (props.selectedWord ? '解释单词' : '解释整句'))
+const speakLabel   = computed(() => (props.selectedWord ? '发音单词' : '发音整句'))
+const subWord      = computed(() => props.selectedWord?.display || '')
+
+const explainAria = computed(() =>
+  props.selectedWord
+    ? `解释 · 当前作用对象 ${props.selectedWord.display}`
+    : '解释 · 整句'
+)
+const speakAria = computed(() =>
+  props.selectedWord
+    ? `发音 · 当前作用对象 ${props.selectedWord.display}`
+    : '发音 · 整句'
+)
+
+const playbackDisabled = computed(() => !props.hasRecording)
+</script>
+
+<template>
+  <div class="dock">
+    <!-- coach bar -->
+    <div class="coach-bar" :class="coachClass" role="status" aria-live="polite">
+      <span class="ico" aria-hidden="true">🎯</span>
+      <span class="progress">{{ coachProgress }}</span>
+      <span class="copy">{{ coachCopy }}</span>
+    </div>
+
+    <div class="dock-row">
+      <button
+        class="dock-btn primary"
+        :aria-label="explainAria"
+        @click="emit('explain')"
+      >
+        <span class="ico" aria-hidden="true">💡</span>
+        <span class="label">{{ explainLabel }}</span>
+        <span v-if="subWord" class="sub">{{ subWord }}</span>
+      </button>
+      <button
+        class="dock-btn primary"
+        :aria-label="speakAria"
+        @click="emit('speak')"
+      >
+        <span class="ico" aria-hidden="true">🔊</span>
+        <span class="label">{{ speakLabel }}</span>
+        <span v-if="subWord" class="sub">{{ subWord }}</span>
+      </button>
+    </div>
+    <div class="dock-row">
+      <button
+        class="dock-btn record"
+        :class="{ recording }"
+        :aria-pressed="recording"
+        :aria-label="recording ? '停止录音' : '开始录音'"
+        @click="emit('toggle-record')"
+      >
+        <span class="ico" aria-hidden="true">{{ recording ? '⏹' : '🎤' }}</span>
+        <span class="label">{{ recording ? '停止' : '录音' }}</span>
+        <span class="sub">
+          {{ recording ? '录音中…' : (hasRecording ? '重录' : '开始录') }}
+        </span>
+      </button>
+      <button
+        class="dock-btn"
+        :aria-disabled="playbackDisabled"
+        :aria-label="playbackDisabled ? '回放，先录一段' : '回放录音'"
+        @click="emit('playback')"
+      >
+        <span class="ico" aria-hidden="true">▶</span>
+        <span class="label">回放</span>
+        <span class="sub">{{ playbackDisabled ? '无录音' : '听自己' }}</span>
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.dock {
+  position: sticky;
+  bottom: 0;
+  background: var(--bg-overlay);
+  backdrop-filter: saturate(180%) blur(20px);
+  -webkit-backdrop-filter: saturate(180%) blur(20px);
+  border-top: 1px solid var(--border);
+  padding: var(--space-2) var(--space-3);
+  padding-bottom: calc(var(--space-2) + var(--safe-bottom));
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  z-index: 5;
+}
+.coach-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px var(--space-3);
+  background: var(--bg-elevated);
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+  color: var(--text-2);
+  line-height: 1.35;
+}
+.coach-bar .ico { font-size: 14px; flex-shrink: 0; }
+.coach-bar .progress { color: var(--text-3); margin-right: 2px; flex-shrink: 0; }
+.coach-bar .copy { flex: 1; min-width: 0; }
+.coach-bar.recording { color: #c6463a; }
+
+.dock-row { display: flex; gap: var(--space-2); }
+.dock-btn {
+  flex: 1;
+  min-height: 56px;
+  border-radius: var(--radius);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  font-family: inherit;
+  color: var(--text-1);
+  cursor: pointer;
+  transition: all 120ms var(--ease);
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+}
+.dock-btn:active { transform: scale(0.96); background: var(--bg); }
+.dock-btn:focus { outline: none; }
+.dock-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.dock-btn .ico { font-size: 20px; line-height: 1; }
+.dock-btn .label { font-size: 13px; font-weight: 500; }
+.dock-btn .sub { font-size: 10px; color: var(--text-3); }
+.dock-btn.primary { background: var(--accent); border-color: var(--accent); color: var(--text-inverse); }
+.dock-btn.primary .sub { color: rgba(255,255,255,0.75); }
+.dock-btn.record.recording {
+  background: #c6463a; border-color: #c6463a; color: #fff;
+  animation: rec-pulse 1s infinite;
+}
+.dock-btn[aria-disabled="true"] { opacity: 0.45; }
+@keyframes rec-pulse {
+  0%,100% { box-shadow: 0 0 0 0 rgba(198,70,58,0.4); }
+  50%    { box-shadow: 0 0 0 8px rgba(198,70,58,0); }
+}
+
+@media (orientation: landscape) and (max-height: 500px) {
+  .dock { padding-bottom: var(--space-2); }
+  .dock-row { gap: var(--space-1); }
+  .dock-btn { min-height: 44px; }
+  .coach-bar { display: none; }
+}
+</style>

--- a/frontend/src/components/practice/MobileSentenceList.vue
+++ b/frontend/src/components/practice/MobileSentenceList.vue
@@ -1,0 +1,213 @@
+<script setup>
+/**
+ * MobileSentenceList · 手机端句子列表 + 当前句卡（含词拆分 + 选词）
+ *
+ * 仅 UI 与 emit；副作用在 Practice.vue。
+ */
+import { computed, nextTick, watch, useTemplateRef } from 'vue'
+import { usePracticeStore } from '@/stores/practice'
+
+const props = defineProps({
+  selectedWord: { type: Object, default: null }, // { word, display } | null
+})
+const emit = defineEmits([
+  'select-sentence',  // (idx: number)
+  'select-word',      // ({ word, display })
+  'clear-word',
+])
+
+const store = usePracticeStore()
+const segments = computed(() => store.segments)
+const currentIdx = computed(() => store.currentIdx)
+const listRef = useTemplateRef('listRef')
+
+// 拆词正则 · 标点保留为文本节点
+const WORD_RE = /([A-Za-z][A-Za-z'-]*)|([^A-Za-z]+)/g
+
+function tokenize(text) {
+  const out = []
+  let m
+  WORD_RE.lastIndex = 0
+  while ((m = WORD_RE.exec(text)) !== null) {
+    out.push(m[1] ? { type: 'word', text: m[1] } : { type: 'sep', text: m[2] })
+  }
+  return out
+}
+
+function isWordSelected(w) {
+  return !!props.selectedWord && props.selectedWord.word === w.toLowerCase()
+}
+
+function onWordClick(rawWord) {
+  const lower = rawWord.toLowerCase()
+  if (props.selectedWord && props.selectedWord.word === lower) {
+    emit('clear-word')
+  } else {
+    emit('select-word', { word: lower, display: rawWord })
+  }
+}
+
+function onSentenceClick(idx, ev) {
+  // 当前句内点词 / 选中条 时，不要触发选句
+  if (ev.target.closest('.word') || ev.target.closest('.selected-bar')) return
+  if (idx !== currentIdx.value) emit('select-sentence', idx)
+}
+
+// 当前句变化时滚到中央
+watch(
+  () => currentIdx.value,
+  async () => {
+    await nextTick()
+    const el = listRef.value?.querySelector(`[data-idx="${currentIdx.value}"]`)
+    if (el) el.scrollIntoView({ block: 'center', behavior: 'smooth' })
+  },
+  { immediate: true }
+)
+</script>
+
+<template>
+  <div ref="listRef" class="m-list">
+    <div
+      v-for="(seg, i) in segments"
+      :key="i"
+      :data-idx="i"
+      class="m-seg"
+      :class="{ current: i === currentIdx }"
+      @click="onSentenceClick(i, $event)"
+    >
+      <div class="idx">{{ i + 1 }}</div>
+      <div class="body">
+        <div class="txt">
+          <template v-if="i === currentIdx">
+            <template v-for="(tok, ti) in tokenize(seg.content)" :key="ti">
+              <button
+                v-if="tok.type === 'word'"
+                type="button"
+                class="word"
+                :aria-pressed="isWordSelected(tok.text)"
+                :aria-label="`单词 ${tok.text}${isWordSelected(tok.text) ? '（已选）' : ''}`"
+                @click.stop="onWordClick(tok.text)"
+              >{{ tok.text }}</button>
+              <template v-else>{{ tok.text }}</template>
+            </template>
+          </template>
+          <template v-else>{{ seg.content }}</template>
+        </div>
+
+        <div
+          v-if="i === currentIdx && selectedWord"
+          class="selected-bar"
+        >
+          <span>⭕ 已选：<b>{{ selectedWord.display }}</b></span>
+          <button
+            type="button"
+            class="clear"
+            aria-label="清除选中词"
+            @click.stop="emit('clear-word')"
+          >×</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.m-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-3) var(--space-4);
+  padding-bottom: var(--space-3);
+  scroll-behavior: smooth;
+}
+.m-seg {
+  display: flex;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  margin-bottom: var(--space-2);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background var(--duration) var(--ease);
+}
+.m-seg:active { background: var(--bg-elevated); }
+.m-seg .idx {
+  font-size: 12px;
+  color: var(--text-3);
+  width: 22px;
+  flex-shrink: 0;
+  padding-top: 3px;
+}
+.m-seg .body { flex: 1; min-width: 0; }
+.m-seg .txt {
+  font-size: 15px;
+  line-height: 1.55;
+  color: var(--text-2);
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  hyphens: auto;
+}
+.m-seg.current {
+  background: var(--bg-elevated);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.04), 0 4px 16px rgba(0,0,0,0.06);
+  border-left: 3px solid var(--accent);
+  padding-left: calc(var(--space-3) - 3px);
+}
+.m-seg.current .idx { color: var(--accent); font-weight: 600; }
+.m-seg.current .txt {
+  font-size: 18px;
+  font-weight: 500;
+  color: var(--text-1);
+}
+
+button.word {
+  display: inline-block;
+  padding: 1px 2px;
+  margin: 0 -1px;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  line-height: inherit;
+  border-radius: 3px;
+  cursor: pointer;
+  transition: background 120ms var(--ease);
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+}
+button.word:focus { outline: none; }
+button.word:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+button.word:active { background: var(--accent-soft); }
+button.word[aria-pressed="true"] {
+  background: var(--accent-soft);
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-decoration-color: var(--accent);
+  text-underline-offset: 3px;
+}
+
+.selected-bar {
+  margin-top: var(--space-3);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px var(--space-3);
+  background: var(--accent-soft);
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+  color: var(--accent);
+}
+.selected-bar .clear {
+  width: 24px; height: 24px;
+  display: grid; place-items: center;
+  border: none;
+  background: transparent;
+  border-radius: 50%;
+  color: var(--accent);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+}
+.selected-bar .clear:focus { outline: none; }
+.selected-bar .clear:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.selected-bar .clear:active { background: var(--bg-elevated); }
+</style>

--- a/frontend/src/composables/__tests__/useCoachBar.spec.js
+++ b/frontend/src/composables/__tests__/useCoachBar.spec.js
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { ref } from 'vue'
+import { useCoachBar } from '../useCoachBar'
+
+function setup(overrides = {}) {
+  const state = {
+    selectedWord:  ref(null),
+    recording:     ref(false),
+    isPlayingTTS:  ref(false),
+    hasRecording:  ref(false),
+    hasPlayedBack: ref(false),
+    currentIdx:    ref(0),
+    totalSegments: ref(9),
+    practicedCount: ref(0),
+    ...overrides,
+  }
+  return { state, ...useCoachBar(state) }
+}
+
+describe('useCoachBar', () => {
+  it('空闲：先听我读一次', () => {
+    const { coachCopy, coachProgress } = setup()
+    expect(coachCopy.value).toBe('先听我读一次')
+    expect(coachProgress.value).toBe('第 1/9 句')
+  })
+
+  it('选词后：解读 "<word>"', () => {
+    const { coachCopy } = setup({ selectedWord: ref({ word: 'schedule', display: 'schedule' }) })
+    expect(coachCopy.value).toBe('解读 "schedule"')
+  })
+
+  it('TTS 播放中：听着…', () => {
+    const { coachCopy } = setup({ isPlayingTTS: ref(true) })
+    expect(coachCopy.value).toBe('听着…')
+  })
+
+  it('录音中：录音中 · 念完点停止', () => {
+    const { coachCopy, coachClass } = setup({ recording: ref(true) })
+    expect(coachCopy.value).toBe('录音中 · 念完点停止')
+    expect(coachClass.value).toBe('recording')
+  })
+
+  it('录完未回放：收到了 · 回放听听自己', () => {
+    const { coachCopy } = setup({ hasRecording: ref(true) })
+    expect(coachCopy.value).toBe('收到了 · 回放听听自己')
+  })
+
+  it('录完已回放：比一比，节奏对齐了吗', () => {
+    const { coachCopy } = setup({
+      hasRecording: ref(true),
+      hasPlayedBack: ref(true),
+    })
+    expect(coachCopy.value).toBe('比一比，节奏对齐了吗')
+  })
+
+  it('已完成 N 句时进度带 · 已完成 N', () => {
+    const { coachProgress } = setup({
+      currentIdx: ref(2),
+      practicedCount: ref(3),
+    })
+    expect(coachProgress.value).toBe('第 3/9 句 · 已完成 3')
+  })
+
+  it('状态优先级：录音 > TTS > 选词 > 录完 > 空闲', () => {
+    const { coachCopy } = setup({
+      selectedWord: ref({ word: 'x', display: 'x' }),
+      hasRecording: ref(true),
+      recording: ref(true),
+    })
+    expect(coachCopy.value).toBe('录音中 · 念完点停止')
+  })
+})

--- a/frontend/src/composables/useBreakpoint.js
+++ b/frontend/src/composables/useBreakpoint.js
@@ -1,0 +1,31 @@
+import { ref, onMounted, onUnmounted } from 'vue'
+
+/**
+ * 响应式 isMobile · 基于 matchMedia('(max-width: 767px)')
+ * 与 spec 的 < 768px 断点对齐
+ *
+ * @returns {Object} { isMobile }
+ * @property {import('vue').Ref<boolean>} isMobile - 是否为移动设备尺寸
+ */
+export function useBreakpoint() {
+  const isMobile = ref(false)
+  let mq = null
+
+  const onChange = (e) => {
+    isMobile.value = e.matches
+  }
+
+  onMounted(() => {
+    mq = window.matchMedia('(max-width: 767px)')
+    isMobile.value = mq.matches
+    mq.addEventListener('change', onChange)
+  })
+
+  onUnmounted(() => {
+    if (mq) {
+      mq.removeEventListener('change', onChange)
+    }
+  })
+
+  return { isMobile }
+}

--- a/frontend/src/composables/useCoachBar.js
+++ b/frontend/src/composables/useCoachBar.js
@@ -1,0 +1,39 @@
+import { computed } from 'vue'
+
+/**
+ * Coach bar 状态机 · 纯派生 · 不持有 state
+ *
+ * 状态优先级：recording > isPlayingTTS > selectedWord > hasPlayedBack > hasRecording > idle
+ *
+ * @param {{
+ *   selectedWord:   import('vue').Ref<{word:string, display:string}|null>,
+ *   recording:      import('vue').Ref<boolean>,
+ *   isPlayingTTS:   import('vue').Ref<boolean>,
+ *   hasRecording:   import('vue').Ref<boolean>,
+ *   hasPlayedBack:  import('vue').Ref<boolean>,
+ *   currentIdx:     import('vue').Ref<number>,
+ *   totalSegments:  import('vue').Ref<number>,
+ *   practicedCount: import('vue').Ref<number>,
+ * }} state
+ */
+export function useCoachBar(state) {
+  const coachCopy = computed(() => {
+    if (state.recording.value) return '录音中 · 念完点停止'
+    if (state.isPlayingTTS.value) return '听着…'
+    if (state.selectedWord.value) return `解读 "${state.selectedWord.value.display}"`
+    if (state.hasRecording.value && state.hasPlayedBack.value) return '比一比，节奏对齐了吗'
+    if (state.hasRecording.value) return '收到了 · 回放听听自己'
+    return '先听我读一次'
+  })
+
+  const coachClass = computed(() => (state.recording.value ? 'recording' : ''))
+
+  const coachProgress = computed(() => {
+    const base = `第 ${state.currentIdx.value + 1}/${state.totalSegments.value} 句`
+    return state.practicedCount.value > 0
+      ? `${base} · 已完成 ${state.practicedCount.value}`
+      : base
+  })
+
+  return { coachCopy, coachClass, coachProgress }
+}

--- a/frontend/src/views/Practice.vue
+++ b/frontend/src/views/Practice.vue
@@ -238,6 +238,8 @@ function onMobileClearWord() {
 }
 
 function onMobileExplain() {
+  // 与 onMobileSpeak 对齐：触发即推进 _lastRequestKey，让在飞 TTS 响应被丢弃
+  _lastRequestKey = `explain:${store.currentIdx}:${selectedWord.value?.word || '__'}:${Date.now()}`
   if (selectedWord.value) {
     onExplain({
       type: 'word',
@@ -442,6 +444,7 @@ onBeforeUnmount(() => {
                   v-for="opt in [
                     { v: 'edge',   label: 'Edge' },
                     { v: 'doubao', label: '豆包' },
+                    { v: 'azure',  label: 'Azure' },
                   ]"
                   :key="opt.v"
                   type="button"
@@ -681,6 +684,8 @@ onBeforeUnmount(() => {
   font-family: inherit;
   cursor: pointer;
 }
+.seg-pick button:focus { outline: none; }
+.seg-pick button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .seg-pick button.active {
   background: var(--accent); color: #fff; border-color: var(--accent);
 }
@@ -704,6 +709,8 @@ onBeforeUnmount(() => {
   transition: background 120ms var(--ease);
 }
 .sheet-action:active { background: var(--bg); }
+.sheet-action:focus { outline: none; }
+.sheet-action:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .sheet-action .sa-ico {
   width: 36px; height: 36px;
   display: grid; place-items: center;

--- a/frontend/src/views/Practice.vue
+++ b/frontend/src/views/Practice.vue
@@ -1,46 +1,97 @@
 <script setup>
 /**
- * Practice · 主战场 2 · V0.8 重写版
- * 迁移自 static/practice.html 1529 行 → 分解为 Import / SentenceList / PracticePlayer
+ * Practice · V0.12 手机端重设计
  *
- * Phase 3 核心路径：
- *   导入字幕 → 选句 → 创建卡片 → 播 TTS → 录音对比 → FSRS 评分
+ * 桌面端 (>= 768px) 仍走 SentenceList + PracticePlayer（不动）。
+ * 手机端 (< 768px) 走 MobileSentenceList + MobileActionDock，
+ * 所有副作用（TTS / 录音 / API / 状态机）集中在本文件。
  *
- * keep-alive include=Practice · onDeactivated 清 TTS & recorder
+ * 设计文档：docs/superpowers/specs/2026-05-12-practice-mobile-redesign.md
+ * 实现计划：docs/superpowers/plans/2026-05-12-practice-mobile-redesign.md
  */
-import { ref, computed, onActivated, onDeactivated } from 'vue'
+import { ref, computed, watch, onActivated, onDeactivated, onBeforeUnmount } from 'vue'
+import { useRouter } from 'vue-router'
 import { usePracticeStore } from '@/stores/practice'
 import { usePractice } from '@/composables/usePractice'
-import { getErrorMessage } from '@/composables/useAuthFetch'
+import { useRecorder } from '@/composables/useRecorder'
+import { useAuthFetch, getErrorMessage } from '@/composables/useAuthFetch'
 import { useScrollLock } from '@/composables/useScrollLock'
+import { useBreakpoint } from '@/composables/useBreakpoint'
+
 import SubtitleImport from '@/components/practice/SubtitleImport.vue'
 import SentenceList from '@/components/practice/SentenceList.vue'
 import PracticePlayer from '@/components/practice/PracticePlayer.vue'
+import MobileSentenceList from '@/components/practice/MobileSentenceList.vue'
+import MobileActionDock from '@/components/practice/MobileActionDock.vue'
 import ExplanationModal from '@/components/ExplanationModal.vue'
-import { useRouter } from 'vue-router'
 
 defineOptions({ name: 'Practice' })
 
 const router = useRouter()
-
 const store = usePracticeStore()
-const { createCards } = usePractice()
+const { createCards, ttsBlob } = usePractice()
+const { authFetch } = useAuthFetch()
+const recorder = useRecorder()
+const { isMobile } = useBreakpoint()
 
+// ---- 通用 / 桌面端原有逻辑 ----
 const explainOpen = ref(false)
 const explainTarget = ref(null)
 const toast = ref({ show: false, text: '', type: 'info' })
-const listDrawerOpen = ref(false)
-useScrollLock(listDrawerOpen)
 
-// 必须有 source 且至少有一段；空段时仍展示导入页面，避免卡死
 const hasSource = computed(
   () => !!store.currentSource && (store.segments?.length || 0) > 0
 )
-
 const isBbcSource = computed(() => {
   const s = store.currentSource
   return !!s && (s.source_type === 'bbc_eaw' || s.type === 'bbc_eaw')
 })
+
+function showToast(text, type = 'info', duration = 2500) {
+  toast.value = { show: true, text, type }
+  setTimeout(() => (toast.value.show = false), duration)
+}
+
+// ---- 手机端本地状态（不入 Pinia） ----
+const selectedWord = ref(null)         // { word, display } | null
+const sheetOpen = ref(false)
+const recordingSegIdx = ref(null)
+const hasPlayedBack = ref(false)
+const isPlayingTTS = ref(false)
+const practicedCount = ref(0)
+let _ttsAudio = null
+let _ttsUrl = null
+let _lastRequestKey = null
+
+useScrollLock(sheetOpen)
+
+const FSRS_NOTICE_KEY = 'v2:practice.fsrs_notice_seen'
+
+// 跨断点（resize 跨 768px）时清状态防泄漏
+watch(isMobile, () => {
+  selectedWord.value = null
+  sheetOpen.value = false
+  _releaseTTS()
+  if (recorder.recording.value) recorder.stop()
+  recordingSegIdx.value = null
+})
+
+// 首次进入弹一次 FSRS toast（仅手机端弹）
+watch(
+  [isMobile, hasSource],
+  ([m, has]) => {
+    if (!m || !has) return
+    try {
+      if (!localStorage.getItem(FSRS_NOTICE_KEY)) {
+        setTimeout(() => {
+          showToast('ℹ︎ 手机端暂不记录复习评分，仍可正常练习', 'info', 4000)
+          localStorage.setItem(FSRS_NOTICE_KEY, '1')
+        }, 400)
+      }
+    } catch { /* ignore */ }
+  },
+  { immediate: true }
+)
 
 function gotoBbcReview() {
   const slug = store.currentSource?.slug || store.currentSource?.id
@@ -48,25 +99,24 @@ function gotoBbcReview() {
   router.push({ name: 'bbc-review', params: { slug } })
 }
 
-function showToast(text, type = 'info', duration = 2500) {
-  toast.value = { show: true, text, type }
-  setTimeout(() => (toast.value.show = false), duration)
+function getAuthHeaders() {
+  try {
+    const t = localStorage.getItem('v2:auth.token') || localStorage.getItem('token')
+    return t ? { Authorization: 'Bearer ' + t } : {}
+  } catch { return {} }
 }
 
 async function onImported(data) {
-  // 给 source 兜底一个 id（新导入时后端可能返回 id，从历史进入时后端返回时可能没带 id）
   if (!data.id && data.source_id) data.id = data.source_id
   store.loadSource(data)
 
-  // Bug fix: CardItem.context 必须是 str，之前发 dict 导致 422
   const segs = (data.segments || []).map((seg, i) => ({
     text: seg.content,
     context: JSON.stringify({ segIdx: i, from: seg.from, to: seg.to }),
-    segIdx: i,  // 前端本地跟踪用，后端 pydantic 会忽略 extras
+    segIdx: i,
   }))
 
   try {
-    // 优先从后端拉该 source 下已有的 cards（历史模式）
     const existingResp = await fetch('/practice/cards?limit=200', {
       headers: getAuthHeaders(),
     })
@@ -74,18 +124,14 @@ async function onImported(data) {
       ? ((await existingResp.json()).cards || [])
       : []
 
-    // segIdx 映射：从 card.context 读出 segIdx；没有就按 text 匹配
     const cardBySegIdx = {}
     for (const c of existingCards) {
       let segIdx = null
       try {
         const ctx = c.context ? JSON.parse(c.context) : {}
         if (typeof ctx.segIdx === 'number') segIdx = ctx.segIdx
-      } catch {
-        /* ignore */
-      }
+      } catch { /* ignore */ }
       if (segIdx == null) {
-        // fallback by text match
         segIdx = segs.findIndex((s) => s.text === c.text)
       }
       if (segIdx >= 0 && segIdx < segs.length) {
@@ -93,11 +139,9 @@ async function onImported(data) {
       }
     }
 
-    // 判断是否需要补创建：缺哪些 segIdx
     const missing = segs.filter((_, i) => !cardBySegIdx[i])
     if (missing.length) {
       await createCards({ items: missing })
-      // POST 只返 {created, skipped}，需要重新 GET 拉完整 cards 列表
       const refetchResp = await fetch('/practice/cards?limit=200', {
         headers: getAuthHeaders(),
       })
@@ -105,17 +149,12 @@ async function onImported(data) {
         ? ((await refetchResp.json()).cards || [])
         : []
       for (const c of refetched) {
-        if (cardBySegIdx[segs.findIndex((s) => s.text === c.text)]) continue
         let segIdx = null
         try {
           const ctx = c.context ? JSON.parse(c.context) : {}
           if (typeof ctx.segIdx === 'number') segIdx = ctx.segIdx
-        } catch {
-          /* ignore */
-        }
-        if (segIdx == null) {
-          segIdx = segs.findIndex((s) => s.text === c.text)
-        }
+        } catch { /* ignore */ }
+        if (segIdx == null) segIdx = segs.findIndex((s) => s.text === c.text)
         if (segIdx >= 0 && segIdx < segs.length) {
           cardBySegIdx[segIdx] = { ...c, segIdx }
         }
@@ -130,25 +169,11 @@ async function onImported(data) {
   }
 }
 
-function getAuthHeaders() {
-  try {
-    const t =
-      localStorage.getItem('v2:auth.token') || localStorage.getItem('token')
-    return t ? { Authorization: 'Bearer ' + t } : {}
-  } catch {
-    return {}
-  }
-}
-
 function onSelect(idx) {
   store.setCurrentIdx(idx)
-  listDrawerOpen.value = false  // 选完关抽屉（手机端）
 }
 
 function onExplain(payload) {
-  // 兼容两种 emit 形式：
-  //   string  → 整句解读
-  //   { type, content, sentence? } → 单词或整句解读
   let target
   if (typeof payload === 'string') {
     target = { type: 'sentence', content: payload }
@@ -156,7 +181,6 @@ function onExplain(payload) {
     target = { type: payload.type, content: payload.content }
     if (payload.sentence) target.sentence = payload.sentence
   }
-  // 来源识别：BBC EAW 走 bbc_eaw 域，便于联动文章级 SRS；其它走 practice
   const src = store.currentSource || {}
   const isBbc = src.source_type === 'bbc_eaw' || src.type === 'bbc_eaw'
   const vocabRef = isBbc
@@ -178,46 +202,157 @@ function onRated({ level }) {
 
 function onNewImport() {
   store.reset()
+  sheetOpen.value = false
 }
 
-onActivated(() => {
-  // 路由切回来时不做特殊恢复；keep-alive 已经保留 state
-})
-onDeactivated(() => {
-  // 不清 state，store 继续保持
+// ---- 手机端：选词 / 切句 / dock 动作 ----
+function _releaseTTS() {
+  if (_ttsAudio) { _ttsAudio.pause(); _ttsAudio = null }
+  if (_ttsUrl)   { URL.revokeObjectURL(_ttsUrl); _ttsUrl = null }
+  isPlayingTTS.value = false
+}
+
+function onMobileSelectSentence(idx) {
+  if (idx === store.currentIdx) return
+  // 状态机：录音中切句要 confirm
+  if (recorder.recording.value) {
+    const ok = window.confirm('正在录音，停止并切换到这一句？')
+    if (!ok) return
+    recorder.stop()
+    recorder.reset()
+    recordingSegIdx.value = null
+  }
+  _releaseTTS()
+  // 离开旧句视作"完成一句"（v1 用切句作信号；issue #26 评分恢复后改为按 Good/Easy 计）
+  if (store.currentIdx !== idx) practicedCount.value += 1
+  store.setCurrentIdx(idx)
+  selectedWord.value = null
+  hasPlayedBack.value = false
+}
+
+function onMobileSelectWord({ word, display }) {
+  selectedWord.value = { word, display }
+}
+function onMobileClearWord() {
+  selectedWord.value = null
+}
+
+function onMobileExplain() {
+  if (selectedWord.value) {
+    onExplain({
+      type: 'word',
+      content: selectedWord.value.display,
+      sentence: store.currentSegment?.content || '',
+    })
+  } else {
+    onExplain(store.currentSegment?.content || '')
+  }
+}
+
+async function onMobileSpeak() {
+  const key = `tts:${store.currentIdx}:${selectedWord.value?.word || '__'}:${Date.now()}`
+  _lastRequestKey = key
+  _releaseTTS()
+  isPlayingTTS.value = true
+  try {
+    const text = selectedWord.value ? selectedWord.value.display : (store.currentSegment?.content || '')
+    if (!text) {
+      isPlayingTTS.value = false
+      return
+    }
+    const blob = await ttsBlob({
+      text,
+      provider: store.provider,
+      speed: store.speed,
+    })
+    if (_lastRequestKey !== key) return // stale 丢弃
+    _ttsUrl = URL.createObjectURL(blob)
+    _ttsAudio = new Audio(_ttsUrl)
+    _ttsAudio.onended = () => { if (_lastRequestKey === key) isPlayingTTS.value = false }
+    await _ttsAudio.play()
+  } catch (err) {
+    const msg = getErrorMessage(err, 'TTS 失败')
+    if (msg) showToast(msg, 'error')
+    isPlayingTTS.value = false
+  }
+}
+
+async function onMobileToggleRecord() {
+  if (recorder.recording.value) {
+    recorder.stop()
+    recordingSegIdx.value = null
+    hasPlayedBack.value = false
+  } else {
+    recorder.reset()
+    await recorder.start()
+    if (recorder.error.value) {
+      showToast(recorder.error.value, 'error')
+      return
+    }
+    recordingSegIdx.value = store.currentIdx
+  }
+}
+
+function onMobilePlayback() {
+  if (!recorder.url.value) {
+    showToast('先录一段', 'info', 1200)
+    return
+  }
+  const a = new Audio(recorder.url.value)
+  a.play()
+  hasPlayedBack.value = true
+}
+
+function onOpenSettings() { sheetOpen.value = true }
+function onCloseSettings() { sheetOpen.value = false }
+
+// 切句时清 TTS
+watch(
+  () => store.currentIdx,
+  (n, o) => {
+    if (n === o) return
+    _releaseTTS()
+  }
+)
+
+onActivated(() => {})
+onDeactivated(() => {})
+onBeforeUnmount(() => {
+  _releaseTTS()
+  recorder.reset()
 })
 </script>
 
 <template>
-  <div class="practice-page">
+  <div class="practice-page" :class="{ mobile: isMobile }">
     <header class="topbar">
       <RouterLink class="back" to="/">← 返回</RouterLink>
       <div class="title">发音练习</div>
       <div class="topbar-right">
-        <!-- 手机端打开句子列表抽屉 -->
+        <!-- 桌面端原有按钮 -->
+        <template v-if="!isMobile">
+          <button
+            v-if="hasSource && isBbcSource"
+            class="bbc-btn"
+            @click="gotoBbcReview"
+            title="开始/继续这篇 BBC 文章的 SRS 复习"
+          >📖 复习</button>
+          <button
+            v-if="hasSource"
+            class="new-btn"
+            @click="onNewImport"
+            title="重新导入字幕"
+          >🔄</button>
+        </template>
+        <!-- 手机端：单一 ⚙ 设置入口 -->
         <button
-          v-if="hasSource"
-          class="list-btn mobile-only"
-          @click="listDrawerOpen = true"
-          :title="`句子列表 ${store.currentIdx + 1}/${store.segments.length}`"
+          v-if="isMobile && hasSource"
+          class="settings-btn"
+          @click="onOpenSettings"
+          aria-label="打开设置"
         >
-          📜 {{ store.currentIdx + 1 }}/{{ store.segments.length }}
-        </button>
-        <button
-          v-if="hasSource && isBbcSource"
-          class="bbc-btn"
-          @click="gotoBbcReview"
-          title="开始/继续这篇 BBC 文章的 SRS 复习"
-        >
-          📖 复习
-        </button>
-        <button
-          v-if="hasSource"
-          class="new-btn"
-          @click="onNewImport"
-          title="重新导入字幕"
-        >
-          🔄
+          <span aria-hidden="true">⚙</span>
+          <span>设置</span>
         </button>
       </div>
     </header>
@@ -226,9 +361,9 @@ onDeactivated(() => {
       <SubtitleImport @imported="onImported" />
     </div>
 
-    <div v-else class="layout">
-      <!-- 桌面端左栏 · 手机端通过抽屉展示同一组件 -->
-      <aside class="left desktop-only">
+    <!-- 桌面端布局 -->
+    <div v-else-if="!isMobile" class="layout">
+      <aside class="left">
         <div class="progress">
           <div class="progress-bar" :style="{ width: `${store.progressPct}%` }"></div>
         </div>
@@ -248,29 +383,106 @@ onDeactivated(() => {
       </main>
     </div>
 
-    <!-- 手机端句子列表抽屉 -->
+    <!-- 手机端布局 -->
+    <template v-else>
+      <MobileSentenceList
+        :selected-word="selectedWord"
+        @select-sentence="onMobileSelectSentence"
+        @select-word="onMobileSelectWord"
+        @clear-word="onMobileClearWord"
+      />
+      <MobileActionDock
+        :selected-word="selectedWord"
+        :recording="recorder.recording.value"
+        :is-playing-t-t-s="isPlayingTTS"
+        :has-recording="!!recorder.url.value"
+        :has-played-back="hasPlayedBack"
+        :current-idx="store.currentIdx"
+        :total-segments="store.segments.length"
+        :practiced-count="practicedCount"
+        @explain="onMobileExplain"
+        @speak="onMobileSpeak"
+        @toggle-record="onMobileToggleRecord"
+        @playback="onMobilePlayback"
+      />
+    </template>
+
+    <!-- ⚙ 手机端 sheet -->
     <Teleport to="body">
-      <Transition name="list-drawer">
+      <Transition name="sheet">
         <div
-          v-if="listDrawerOpen && hasSource"
-          class="list-drawer-overlay"
-          @click.self="listDrawerOpen = false"
+          v-if="sheetOpen"
+          class="sheet-mask"
+          @click.self="onCloseSettings"
+          @keydown.esc="onCloseSettings"
         >
-          <aside class="list-drawer">
-            <header class="ld-head">
-              <h3>📜 句子列表 · {{ store.currentIdx + 1 }}/{{ store.segments.length }}</h3>
-              <button class="ld-close" @click="listDrawerOpen = false" aria-label="关闭">×</button>
-            </header>
-            <div class="ld-progress">
-              <div class="ld-progress-bar" :style="{ width: `${store.progressPct}%` }"></div>
+          <aside class="sheet" role="dialog" aria-modal="true" aria-labelledby="sheet-title">
+            <h4 id="sheet-title">设置</h4>
+            <div class="sheet-row">
+              <label>语速</label>
+              <div class="seg-pick">
+                <button
+                  v-for="opt in [
+                    { v: '-40%', label: '慢' },
+                    { v: '-20%', label: '偏慢' },
+                    { v: '+0%',  label: '正常' },
+                    { v: '+20%', label: '偏快' },
+                  ]"
+                  :key="opt.v"
+                  type="button"
+                  :class="{ active: store.speed === opt.v }"
+                  @click="store.speed = opt.v"
+                >{{ opt.label }}</button>
+              </div>
             </div>
-            <div class="ld-stats">
-              {{ store.totalPracticed }}/{{ store.segments.length }} 已练 ·
-              Again: {{ store.ratingResults.again }} ·
-              Good: {{ store.ratingResults.good }}
+            <div class="sheet-row">
+              <label>TTS 引擎</label>
+              <div class="seg-pick">
+                <button
+                  v-for="opt in [
+                    { v: 'edge',   label: 'Edge' },
+                    { v: 'doubao', label: '豆包' },
+                  ]"
+                  :key="opt.v"
+                  type="button"
+                  :class="{ active: store.provider === opt.v }"
+                  @click="store.provider = opt.v"
+                >{{ opt.label }}</button>
+              </div>
             </div>
-            <div class="ld-body">
-              <SentenceList @select="onSelect" @explain="onExplain" />
+
+            <div class="sheet-divider"></div>
+
+            <button
+              v-if="isBbcSource"
+              class="sheet-action"
+              type="button"
+              @click="gotoBbcReview(); onCloseSettings()"
+            >
+              <span class="sa-ico">📖</span>
+              <span class="sa-body">
+                <span class="sa-title">BBC 复习</span>
+                <span class="sa-desc">基于 SRS 的文章复习</span>
+              </span>
+              <span class="sa-chev">›</span>
+            </button>
+            <button
+              class="sheet-action"
+              type="button"
+              @click="onNewImport()"
+            >
+              <span class="sa-ico">🔄</span>
+              <span class="sa-body">
+                <span class="sa-title">重新导入字幕</span>
+                <span class="sa-desc">换一集、换一篇</span>
+              </span>
+              <span class="sa-chev">›</span>
+            </button>
+
+            <div class="sheet-footer-note">
+              ℹ︎ 关于复习评分 · 手机端暂不评分，本次练习不会进入 FSRS 复习计划；
+              如需评分请到桌面端，或关注
+              <a href="https://github.com/bob798/speakeasy/issues/26" target="_blank" rel="noopener">issue #26</a>。
             </div>
           </aside>
         </div>
@@ -315,8 +527,8 @@ onDeactivated(() => {
   gap: var(--space-2);
   align-items: center;
 }
+
 .new-btn,
-.list-btn,
 .bbc-btn {
   padding: 6px var(--space-3);
   border-radius: var(--radius-sm);
@@ -328,11 +540,6 @@ onDeactivated(() => {
   touch-action: manipulation;
   white-space: nowrap;
 }
-.list-btn {
-  background: var(--bg-elevated);
-  color: var(--text-1);
-  border: 1px solid var(--border);
-}
 .bbc-btn {
   background: rgba(61, 107, 79, 0.18);
   color: var(--accent);
@@ -343,13 +550,32 @@ onDeactivated(() => {
   background: var(--accent);
   color: var(--text-inverse);
 }
-.new-btn:active,
-.list-btn:active {
-  transform: scale(0.96);
-}
 .new-btn:active {
+  transform: scale(0.96);
   background: var(--accent-hover);
 }
+
+/* mobile ⚙ 设置 胶囊按钮 */
+.settings-btn {
+  min-width: 44px;
+  height: 36px;
+  padding: 0 12px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  border-radius: 18px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 14px;
+  font-weight: 500;
+  font-family: inherit;
+  border: none;
+  cursor: pointer;
+}
+.settings-btn:focus { outline: none; }
+.settings-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.settings-btn:active { background: var(--accent); color: var(--text-inverse); transform: scale(0.96); }
+
 .import-wrap {
   max-width: 560px;
   width: 100%;
@@ -357,35 +583,15 @@ onDeactivated(() => {
   padding: 0 var(--space-4);
 }
 
-/* 默认：手机单栏（PracticePlayer 全宽），左栏隐藏 */
+/* 桌面端 layout · 沿用 */
 .layout {
   flex: 1;
-  display: block;
+  display: grid;
+  grid-template-columns: minmax(220px, 36%) 1fr;
+  gap: var(--space-3);
   padding: var(--space-3) var(--space-4);
   min-height: 0;
 }
-.desktop-only {
-  display: none;
-}
-.mobile-only {
-  display: inline-flex;
-}
-
-/* ≥768px：双栏，桌面端原布局 */
-@media (min-width: 768px) {
-  .layout {
-    display: grid;
-    grid-template-columns: minmax(220px, 36%) 1fr;
-    gap: var(--space-3);
-  }
-  .desktop-only {
-    display: flex;
-  }
-  .mobile-only {
-    display: none;
-  }
-}
-
 .left {
   display: flex;
   flex-direction: column;
@@ -414,6 +620,10 @@ onDeactivated(() => {
 .right {
   min-height: 0;
 }
+
+/* 手机端：layout 块隐藏 · 让 MobileSentenceList(flex:1) + sticky Dock 接管 */
+.practice-page.mobile .layout { display: none; }
+
 .toast {
   position: fixed;
   bottom: calc(var(--safe-bottom) + var(--space-5));
@@ -425,97 +635,110 @@ onDeactivated(() => {
   border-radius: var(--radius);
   font-size: 13px;
   z-index: var(--z-toast);
+  max-width: calc(100% - var(--space-5) * 2);
+  text-align: center;
 }
-.toast.error {
-  background: #c6463a;
-}
+.toast.error { background: #c6463a; }
 .toast-enter-active,
-.toast-leave-active {
-  transition: opacity var(--duration) var(--ease);
-}
+.toast-leave-active { transition: opacity var(--duration) var(--ease); }
 .toast-enter-from,
-.toast-leave-to {
-  opacity: 0;
-}
+.toast-leave-to { opacity: 0; }
 
-/* 句子列表抽屉 · 手机端从左滑入 */
-.list-drawer-overlay {
+/* ⚙ sheet · 底部 */
+.sheet-mask {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.4);
+  background: rgba(0,0,0,0.4);
   z-index: var(--z-modal);
   display: flex;
+  align-items: flex-end;
 }
-.list-drawer {
-  width: 90%;
-  max-width: 380px;
-  height: 100dvh;
-  background: var(--bg);
-  display: flex;
-  flex-direction: column;
-  box-shadow: 4px 0 24px rgba(0, 0, 0, 0.15);
+.sheet {
+  width: 100%;
+  background: var(--bg-elevated);
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  padding: var(--space-4);
+  padding-bottom: calc(var(--space-4) + var(--safe-bottom));
+  max-height: 80dvh;
+  overflow-y: auto;
 }
-.ld-head {
+.sheet h4 { margin: 0 0 var(--space-3); font-size: 14px; color: var(--text-2); }
+.sheet-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: var(--space-3) var(--space-4);
-  padding-top: calc(var(--safe-top) + var(--space-3));
-  background: var(--bg-elevated);
-  border-bottom: 1px solid var(--border);
+  padding: 10px 0;
 }
-.ld-head h3 {
-  margin: 0;
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--text-1);
-}
-.ld-close {
-  width: 32px;
-  height: 32px;
-  display: grid;
-  place-items: center;
-  font-size: 22px;
-  line-height: 1;
+.sheet-row label { font-size: 14px; color: var(--text-1); }
+.seg-pick { display: flex; gap: 4px; }
+.seg-pick button {
+  padding: 6px 10px;
+  font-size: 12px;
+  border-radius: var(--radius-sm);
+  background: var(--bg);
   color: var(--text-2);
-  border-radius: 50%;
-  background: transparent;
+  border: 1px solid var(--border);
+  font-family: inherit;
+  cursor: pointer;
 }
-.ld-progress {
-  height: 4px;
+.seg-pick button.active {
+  background: var(--accent); color: #fff; border-color: var(--accent);
+}
+.sheet-divider {
+  height: 1px;
   background: var(--border);
+  margin: 12px 0;
 }
-.ld-progress-bar {
-  height: 100%;
-  background: var(--accent);
-  transition: width var(--duration) var(--ease);
+.sheet-action {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 10px 8px;
+  border: none;
+  background: transparent;
+  border-radius: var(--radius);
+  cursor: pointer;
+  font-family: inherit;
+  text-align: left;
+  transition: background 120ms var(--ease);
 }
-.ld-stats {
-  padding: 6px var(--space-4);
+.sheet-action:active { background: var(--bg); }
+.sheet-action .sa-ico {
+  width: 36px; height: 36px;
+  display: grid; place-items: center;
+  background: var(--accent-soft);
+  color: var(--accent);
+  border-radius: var(--radius-sm);
+  font-size: 18px;
+}
+.sheet-action .sa-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+}
+.sheet-action .sa-title { font-size: 14px; color: var(--text-1); font-weight: 500; }
+.sheet-action .sa-desc { font-size: 11px; color: var(--text-3); }
+.sheet-action .sa-chev { color: var(--text-3); font-size: 18px; }
+.sheet-footer-note {
+  margin-top: 12px;
+  padding: 10px 12px;
+  background: var(--bg);
+  border-radius: var(--radius-sm);
   font-size: 11px;
   color: var(--text-3);
-  border-bottom: 1px solid var(--border);
+  line-height: 1.5;
 }
-.ld-body {
-  flex: 1;
-  overflow-y: auto;
-  padding-bottom: calc(var(--safe-bottom) + var(--space-3));
-}
+.sheet-footer-note a { color: var(--accent); text-decoration: underline; }
 
-.list-drawer-enter-active,
-.list-drawer-leave-active {
-  transition: opacity 0.2s ease;
+.sheet-enter-active, .sheet-leave-active {
+  transition: opacity 200ms var(--ease);
 }
-.list-drawer-enter-active .list-drawer,
-.list-drawer-leave-active .list-drawer {
-  transition: transform 0.25s cubic-bezier(0.32, 0.72, 0, 1);
+.sheet-enter-active .sheet, .sheet-leave-active .sheet {
+  transition: transform 220ms var(--ease);
 }
-.list-drawer-enter-from,
-.list-drawer-leave-to {
-  opacity: 0;
-}
-.list-drawer-enter-from .list-drawer,
-.list-drawer-leave-to .list-drawer {
-  transform: translateX(-100%);
-}
+.sheet-enter-from, .sheet-leave-to { opacity: 0; }
+.sheet-enter-from .sheet, .sheet-leave-to .sheet { transform: translateY(100%); }
 </style>

--- a/frontend/src/views/Practice.vue
+++ b/frontend/src/views/Practice.vue
@@ -305,8 +305,35 @@ function onMobilePlayback() {
   hasPlayedBack.value = true
 }
 
-function onOpenSettings() { sheetOpen.value = true }
-function onCloseSettings() { sheetOpen.value = false }
+// ⚙ sheet 焦点管理（spec §可访问性 #5）
+const sheetTriggerRef = ref(null)
+const sheetRef = ref(null)
+const INERT_SELECTORS = '.topbar, .m-list, .dock, .layout'
+
+function onOpenSettings() {
+  sheetTriggerRef.value = document.activeElement
+  sheetOpen.value = true
+  // 屏蔽背景 a11y 树
+  document.querySelectorAll(INERT_SELECTORS).forEach((el) => el.setAttribute('inert', ''))
+  // 等下一帧 DOM 出现再 focus
+  setTimeout(() => {
+    const first = sheetRef.value?.querySelector('button')
+    if (first) first.focus()
+  }, 60)
+}
+function onCloseSettings() {
+  sheetOpen.value = false
+  document.querySelectorAll(INERT_SELECTORS).forEach((el) => el.removeAttribute('inert'))
+  if (sheetTriggerRef.value && typeof sheetTriggerRef.value.focus === 'function') {
+    sheetTriggerRef.value.focus()
+  }
+}
+
+// Esc 关闭 sheet
+function _onEscape(e) {
+  if (e.key === 'Escape' && sheetOpen.value) onCloseSettings()
+}
+window.addEventListener('keydown', _onEscape)
 
 // 切句时清 TTS
 watch(
@@ -322,6 +349,7 @@ onDeactivated(() => {})
 onBeforeUnmount(() => {
   _releaseTTS()
   recorder.reset()
+  window.removeEventListener('keydown', _onEscape)
 })
 </script>
 
@@ -418,7 +446,7 @@ onBeforeUnmount(() => {
           @click.self="onCloseSettings"
           @keydown.esc="onCloseSettings"
         >
-          <aside class="sheet" role="dialog" aria-modal="true" aria-labelledby="sheet-title">
+          <aside ref="sheetRef" class="sheet" role="dialog" aria-modal="true" aria-labelledby="sheet-title">
             <h4 id="sheet-title">设置</h4>
             <div class="sheet-row">
               <label>语速</label>

--- a/mockups/practice-mobile-v2.html
+++ b/mockups/practice-mobile-v2.html
@@ -1,0 +1,614 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+<title>Practice · Mobile v2 prototype</title>
+<style>
+  :root {
+    --accent: #3d6b4f;
+    --accent-hover: #335e44;
+    --accent-soft: #eaf3ee;
+    --bg: #f7f7f5;
+    --bg-elevated: #ffffff;
+    --bg-overlay: rgba(255, 255, 255, 0.92);
+    --text-1: #1a1d1f;
+    --text-2: #4a5159;
+    --text-3: #8a9199;
+    --text-inverse: #ffffff;
+    --border: #e3e6e8;
+    --border-strong: #c5c9cd;
+    --radius-sm: 6px;
+    --radius: 10px;
+    --radius-lg: 16px;
+    --space-1: 4px;
+    --space-2: 8px;
+    --space-3: 12px;
+    --space-4: 16px;
+    --space-5: 24px;
+    --space-6: 32px;
+    --font-sans: -apple-system, BlinkMacSystemFont, 'SF Pro SC', 'PingFang SC',
+      'Helvetica Neue', sans-serif;
+    --ease: cubic-bezier(0.4, 0, 0.2, 1);
+    --duration: 180ms;
+  }
+
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; font-family: var(--font-sans); color: var(--text-1); }
+  body {
+    background: #d4d7d9;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px 8px;
+  }
+  button { border: none; cursor: pointer; font: inherit; color: inherit; background: transparent; }
+  button:focus { outline: none; }
+
+  /* 模拟手机外壳 · 实际端跑时去掉这层 */
+  .device {
+    width: 100%;
+    max-width: 390px;
+    height: 844px;
+    max-height: 95vh;
+    background: var(--bg);
+    border-radius: 36px;
+    overflow: hidden;
+    box-shadow: 0 24px 60px rgba(0,0,0,0.18);
+    display: flex;
+    flex-direction: column;
+    position: relative;
+  }
+
+  /* 顶栏 */
+  .topbar {
+    height: 56px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 var(--space-4);
+    background: var(--bg-overlay);
+    backdrop-filter: saturate(180%) blur(16px);
+    -webkit-backdrop-filter: saturate(180%) blur(16px);
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+    position: relative;
+    z-index: 10;
+  }
+  .topbar .back { color: var(--text-2); font-size: 14px; padding: 8px 4px; }
+  .topbar .title { font-weight: 600; color: var(--accent); font-size: 15px; }
+  .topbar .right { display: flex; gap: var(--space-1); }
+  .topbar .icon-btn {
+    min-width: 44px;
+    height: 36px;
+    padding: 0 12px;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    border-radius: 18px;
+    background: var(--accent-soft);
+    color: var(--accent);
+    font-size: 14px;
+    font-weight: 500;
+  }
+  .topbar .icon-btn .ico { font-size: 16px; }
+  .topbar .icon-btn:active { background: var(--accent); color: var(--text-inverse); transform: scale(0.96); }
+
+  /* 句子列表区 */
+  .list {
+    flex: 1;
+    overflow-y: auto;
+    padding: var(--space-3) var(--space-4);
+    padding-bottom: 160px; /* 给 dock 让位 */
+    scroll-behavior: smooth;
+  }
+  .seg {
+    display: flex;
+    gap: var(--space-3);
+    padding: var(--space-3) var(--space-3);
+    margin-bottom: var(--space-2);
+    border-radius: var(--radius);
+    cursor: pointer;
+    transition: background var(--duration) var(--ease);
+  }
+  .seg:active { background: var(--bg-elevated); }
+  .seg .idx {
+    font-size: 12px;
+    color: var(--text-3);
+    width: 22px;
+    flex-shrink: 0;
+    padding-top: 3px;
+  }
+  .seg .body { flex: 1; }
+  .seg .body .txt {
+    font-size: 15px;
+    line-height: 1.55;
+    color: var(--text-2);
+  }
+  /* FSRS 状态点暂去除 · issue #26 重做评分后再考虑加回 */
+
+  /* 当前句卡 */
+  .seg.current {
+    background: var(--bg-elevated);
+    box-shadow: 0 1px 2px rgba(0,0,0,0.04), 0 4px 16px rgba(0,0,0,0.06);
+    border-left: 3px solid var(--accent);
+    padding-left: calc(var(--space-3) - 3px);
+  }
+  .seg.current .idx { color: var(--accent); font-weight: 600; }
+  .seg.current .txt {
+    font-size: 18px;
+    font-weight: 500;
+    color: var(--text-1);
+    line-height: 1.55;
+  }
+
+  /* 当前句里的单词 · 可点 */
+  .word {
+    display: inline-block;
+    padding: 1px 2px;
+    margin: 0 -1px;
+    border-radius: 3px;
+    cursor: pointer;
+    transition: background 120ms var(--ease);
+  }
+  .word:active { background: var(--accent-soft); }
+  .word.selected {
+    background: var(--accent-soft);
+    color: var(--accent);
+    text-decoration: underline;
+    text-decoration-thickness: 2px;
+    text-decoration-color: var(--accent);
+    text-underline-offset: 3px;
+  }
+
+  /* 选中词条 */
+  .selected-bar {
+    margin-top: var(--space-3);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 6px var(--space-3);
+    background: var(--accent-soft);
+    border-radius: var(--radius-sm);
+    font-size: 12px;
+    color: var(--accent);
+  }
+  .selected-bar .clear {
+    width: 24px; height: 24px;
+    display: grid; place-items: center;
+    border-radius: 50%;
+    color: var(--accent);
+    font-size: 16px;
+    line-height: 1;
+  }
+  .selected-bar .clear:active { background: var(--bg-elevated); }
+
+  /* dock */
+  .dock {
+    position: absolute;
+    left: 0; right: 0; bottom: 0;
+    background: var(--bg-overlay);
+    backdrop-filter: saturate(180%) blur(20px);
+    -webkit-backdrop-filter: saturate(180%) blur(20px);
+    border-top: 1px solid var(--border);
+    padding: var(--space-2) var(--space-3);
+    padding-bottom: calc(var(--space-2) + 12px); /* mock safe-bottom */
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    z-index: 5;
+  }
+  .dock-row { display: flex; gap: var(--space-2); }
+  .dock-btn {
+    flex: 1;
+    min-height: 56px;
+    border-radius: var(--radius);
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
+    transition: all 120ms var(--ease);
+  }
+  .dock-btn:active { transform: scale(0.96); background: var(--bg); }
+  .dock-btn .ico { font-size: 20px; line-height: 1; }
+  .dock-btn .label { font-size: 13px; color: var(--text-1); font-weight: 500; }
+  .dock-btn .sub { font-size: 10px; color: var(--text-3); }
+  .dock-btn.primary { background: var(--accent); border-color: var(--accent); }
+  .dock-btn.primary .label, .dock-btn.primary .ico { color: var(--text-inverse); }
+  .dock-btn.primary .sub { color: rgba(255,255,255,0.75); }
+  .dock-btn.record.recording {
+    background: #c6463a; border-color: #c6463a;
+    animation: rec-pulse 1s infinite;
+  }
+  .dock-btn.record.recording .label, .dock-btn.record.recording .ico { color: #fff; }
+  .dock-btn:disabled, .dock-btn.disabled {
+    opacity: 0.45;
+    pointer-events: auto; /* 仍可点出 toast */
+  }
+  @keyframes rec-pulse {
+    0%,100% { box-shadow: 0 0 0 0 rgba(198,70,58,0.4); }
+    50% { box-shadow: 0 0 0 8px rgba(198,70,58,0); }
+  }
+
+  /* ⚙ sheet */
+  .sheet-mask {
+    position: absolute; inset: 0;
+    background: rgba(0,0,0,0.4);
+    z-index: 20;
+    display: none;
+  }
+  .sheet-mask.open { display: block; }
+  .sheet {
+    position: absolute;
+    left: 0; right: 0; bottom: 0;
+    background: var(--bg-elevated);
+    border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+    padding: var(--space-4) var(--space-4) calc(var(--space-4) + 12px);
+    z-index: 21;
+    transform: translateY(100%);
+    transition: transform 220ms var(--ease);
+  }
+  .sheet.open { transform: translateY(0); }
+  .sheet h4 { margin: 0 0 var(--space-3); font-size: 14px; color: var(--text-2); }
+  .row { display: flex; align-items: center; justify-content: space-between; padding: 10px 0; }
+  .row label { font-size: 14px; color: var(--text-1); }
+  .seg-pick { display: flex; gap: 4px; }
+  .seg-pick button {
+    padding: 6px 10px;
+    font-size: 12px;
+    border-radius: var(--radius-sm);
+    background: var(--bg);
+    color: var(--text-2);
+    border: 1px solid var(--border);
+  }
+  .seg-pick button.active {
+    background: var(--accent); color: #fff; border-color: var(--accent);
+  }
+  .sheet-divider {
+    height: 1px;
+    background: var(--border);
+    margin: 12px 0;
+  }
+  .sheet-action {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    padding: 10px 8px;
+    border-radius: var(--radius);
+    transition: background 120ms var(--ease);
+  }
+  .sheet-action:active { background: var(--bg); }
+  .sheet-action .sa-ico {
+    width: 36px; height: 36px;
+    display: grid; place-items: center;
+    background: var(--accent-soft);
+    color: var(--accent);
+    border-radius: var(--radius-sm);
+    font-size: 18px;
+  }
+  .sheet-action .sa-body {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+  }
+  .sheet-action .sa-title { font-size: 14px; color: var(--text-1); font-weight: 500; }
+  .sheet-action .sa-desc { font-size: 11px; color: var(--text-3); }
+  .sheet-action .sa-chev { color: var(--text-3); font-size: 18px; }
+
+  /* toast */
+  .toast {
+    position: absolute;
+    bottom: 200px; left: 50%;
+    transform: translateX(-50%);
+    background: var(--text-1);
+    color: #fff;
+    padding: 8px 16px;
+    border-radius: var(--radius);
+    font-size: 13px;
+    opacity: 0;
+    transition: opacity 200ms var(--ease);
+    z-index: 30;
+    pointer-events: none;
+  }
+  .toast.show { opacity: 1; }
+</style>
+</head>
+<body>
+  <div class="device">
+    <!-- 顶栏 -->
+    <header class="topbar">
+      <button class="back" onclick="alert('返回 Home（原型只演示，不实际跳）')">← 返回</button>
+      <div class="title">发音练习</div>
+      <div class="right">
+        <button class="icon-btn" title="设置" onclick="openSheet()">
+          <span class="ico">⚙</span><span>设置</span>
+        </button>
+      </div>
+    </header>
+
+    <!-- 句子列表 -->
+    <div class="list" id="list"></div>
+
+    <!-- 底部 dock -->
+    <div class="dock">
+      <div class="dock-row">
+        <button class="dock-btn primary" onclick="onExplain()">
+          <span class="ico">💡</span>
+          <span class="label">解释</span>
+          <span class="sub" id="explainSub">整句</span>
+        </button>
+        <button class="dock-btn primary" onclick="onSpeak()">
+          <span class="ico">🔊</span>
+          <span class="label">发音</span>
+          <span class="sub" id="speakSub">整句</span>
+        </button>
+      </div>
+      <div class="dock-row">
+        <button class="dock-btn record" id="recBtn" onclick="onToggleRec()">
+          <span class="ico" id="recIco">🎤</span>
+          <span class="label" id="recLabel">录音</span>
+          <span class="sub" id="recSub">开始录</span>
+        </button>
+        <button class="dock-btn disabled" id="playbackBtn" onclick="onPlayback()">
+          <span class="ico">▶</span>
+          <span class="label">回放</span>
+          <span class="sub" id="playbackSub">无录音</span>
+        </button>
+      </div>
+    </div>
+
+    <!-- ⚙ sheet -->
+    <div class="sheet-mask" id="sheetMask" onclick="closeSheet()"></div>
+    <div class="sheet" id="sheet">
+      <h4>设置</h4>
+      <div class="row">
+        <label>语速</label>
+        <div class="seg-pick" id="speedPick">
+          <button data-v="-40%">慢</button>
+          <button data-v="-20%">偏慢</button>
+          <button data-v="+0%" class="active">正常</button>
+          <button data-v="+20%">偏快</button>
+        </div>
+      </div>
+      <div class="row">
+        <label>TTS 引擎</label>
+        <div class="seg-pick" id="engPick">
+          <button data-v="edge" class="active">Edge</button>
+          <button data-v="doubao">豆包</button>
+          <button data-v="azure">Azure</button>
+        </div>
+      </div>
+
+      <div class="sheet-divider"></div>
+
+      <button class="sheet-action" onclick="toast('📖 跳 BBC 复习页（mock）'); closeSheet();">
+        <span class="sa-ico">📖</span>
+        <span class="sa-body">
+          <span class="sa-title">BBC 复习</span>
+          <span class="sa-desc">基于 SRS 的文章复习</span>
+        </span>
+        <span class="sa-chev">›</span>
+      </button>
+      <button class="sheet-action" onclick="toast('🔄 重新导入字幕（mock）'); closeSheet();">
+        <span class="sa-ico">🔄</span>
+        <span class="sa-body">
+          <span class="sa-title">重新导入字幕</span>
+          <span class="sa-desc">换一集、换一篇</span>
+        </span>
+        <span class="sa-chev">›</span>
+      </button>
+    </div>
+
+    <!-- toast -->
+    <div class="toast" id="toast"></div>
+  </div>
+
+<script>
+  // 模拟 BBC English at Work 一集的句子
+  const segments = [
+    { text: 'Welcome to BBC English at Work.' },
+    { text: 'Today, Anna learns how to ask politely.' },
+    { text: 'Could you give me the schedule for tomorrow?' },
+    { text: 'Sure, you have a meeting at ten.' },
+    { text: 'And another with the client at two.' },
+    { text: 'Right, would you mind if I arrived a bit late?' },
+    { text: 'Not at all, take your time.' },
+    { text: 'Thanks, you are a lifesaver.' },
+    { text: 'See you tomorrow then.' },
+  ];
+
+  let currentIdx = 2;
+  let selectedWord = null; // { word, idx } 或 null
+  let recording = false;
+  let hasRecording = false;
+  let speed = '+0%';
+  let engine = 'edge';
+
+  const listEl = document.getElementById('list');
+  const explainSub = document.getElementById('explainSub');
+  const speakSub = document.getElementById('speakSub');
+  const toastEl = document.getElementById('toast');
+  let toastTimer = null;
+
+  function toast(text) {
+    toastEl.textContent = text;
+    toastEl.classList.add('show');
+    clearTimeout(toastTimer);
+    toastTimer = setTimeout(() => toastEl.classList.remove('show'), 1500);
+  }
+
+  function tokenize(text) {
+    // 拆词 + 保留标点位置
+    const parts = [];
+    const re = /([A-Za-z][A-Za-z'-]*)|([^A-Za-z]+)/g;
+    let m;
+    while ((m = re.exec(text)) !== null) {
+      if (m[1]) parts.push({ type: 'word', text: m[1] });
+      else parts.push({ type: 'sep', text: m[2] });
+    }
+    return parts;
+  }
+
+  function render() {
+    listEl.innerHTML = '';
+    segments.forEach((seg, i) => {
+      const isCurrent = i === currentIdx;
+      const segEl = document.createElement('div');
+      segEl.className = 'seg' + (isCurrent ? ' current' : '');
+      segEl.onclick = (e) => {
+        // 当前句内点词时，不要触发选句
+        if (e.target.closest('.word') || e.target.closest('.selected-bar')) return;
+        if (i !== currentIdx) {
+          currentIdx = i;
+          selectedWord = null;
+          render();
+          scrollToCurrent();
+        }
+      };
+
+      const idxEl = document.createElement('div');
+      idxEl.className = 'idx';
+      idxEl.textContent = String(i + 1);
+
+      const body = document.createElement('div');
+      body.className = 'body';
+
+      const txt = document.createElement('div');
+      txt.className = 'txt';
+      if (isCurrent) {
+        // 拆词
+        tokenize(seg.text).forEach((tok) => {
+          if (tok.type === 'word') {
+            const b = document.createElement('span');
+            b.className = 'word';
+            if (selectedWord && selectedWord.word === tok.text.toLowerCase()) {
+              b.classList.add('selected');
+            }
+            b.textContent = tok.text;
+            b.onclick = (ev) => {
+              ev.stopPropagation();
+              const w = tok.text.toLowerCase();
+              if (selectedWord && selectedWord.word === w) selectedWord = null;
+              else selectedWord = { word: w, display: tok.text };
+              render();
+            };
+            txt.appendChild(b);
+          } else {
+            txt.appendChild(document.createTextNode(tok.text));
+          }
+        });
+      } else {
+        txt.textContent = seg.text;
+      }
+      body.appendChild(txt);
+
+      if (isCurrent && selectedWord) {
+        const bar = document.createElement('div');
+        bar.className = 'selected-bar';
+        bar.innerHTML = `<span>⭕ 已选：<b>${selectedWord.display}</b></span>`;
+        const clearBtn = document.createElement('button');
+        clearBtn.className = 'clear';
+        clearBtn.textContent = '×';
+        clearBtn.onclick = (ev) => {
+          ev.stopPropagation();
+          selectedWord = null;
+          render();
+        };
+        bar.appendChild(clearBtn);
+        body.appendChild(bar);
+      }
+
+      segEl.appendChild(idxEl);
+      segEl.appendChild(body);
+      listEl.appendChild(segEl);
+    });
+    updateSubs();
+  }
+
+  function updateSubs() {
+    const sub = selectedWord ? selectedWord.display : '整句';
+    explainSub.textContent = sub;
+    speakSub.textContent = sub;
+  }
+
+  function scrollToCurrent() {
+    const segs = listEl.querySelectorAll('.seg');
+    const target = segs[currentIdx];
+    if (target) target.scrollIntoView({ block: 'center', behavior: 'smooth' });
+  }
+
+  // dock 动作
+  function onExplain() {
+    const target = selectedWord ? `单词 "${selectedWord.display}"` : '整句';
+    toast(`💡 解释 ${target}（mock）`);
+  }
+  function onSpeak() {
+    const target = selectedWord ? `单词 "${selectedWord.display}"` : '整句';
+    toast(`🔊 发音 ${target}（mock · speed=${speed} engine=${engine}）`);
+  }
+  function onToggleRec() {
+    recording = !recording;
+    const btn = document.getElementById('recBtn');
+    const ico = document.getElementById('recIco');
+    const label = document.getElementById('recLabel');
+    const sub = document.getElementById('recSub');
+    if (recording) {
+      btn.classList.add('recording');
+      ico.textContent = '⏹';
+      label.textContent = '停止';
+      sub.textContent = '录音中…';
+      toast('🎤 录音中');
+    } else {
+      btn.classList.remove('recording');
+      ico.textContent = '🎤';
+      label.textContent = '录音';
+      sub.textContent = '重录';
+      hasRecording = true;
+      const pb = document.getElementById('playbackBtn');
+      pb.classList.remove('disabled');
+      document.getElementById('playbackSub').textContent = '听自己';
+      toast('⏹ 已停止录音');
+    }
+  }
+  function onPlayback() {
+    if (!hasRecording) { toast('先录一段'); return; }
+    toast('▶ 回放（mock）');
+  }
+
+  // sheet
+  function openSheet() {
+    document.getElementById('sheetMask').classList.add('open');
+    document.getElementById('sheet').classList.add('open');
+  }
+  function closeSheet() {
+    document.getElementById('sheetMask').classList.remove('open');
+    document.getElementById('sheet').classList.remove('open');
+  }
+  document.querySelectorAll('#speedPick button').forEach((b) => {
+    b.onclick = () => {
+      document.querySelectorAll('#speedPick button').forEach((x) => x.classList.remove('active'));
+      b.classList.add('active');
+      speed = b.dataset.v;
+    };
+  });
+  document.querySelectorAll('#engPick button').forEach((b) => {
+    b.onclick = () => {
+      document.querySelectorAll('#engPick button').forEach((x) => x.classList.remove('active'));
+      b.classList.add('active');
+      engine = b.dataset.v;
+    };
+  });
+
+  render();
+  // 等 render 之后再滚到当前句
+  setTimeout(scrollToCurrent, 100);
+</script>
+</body>
+</html>

--- a/mockups/practice-mobile-v2.html
+++ b/mockups/practice-mobile-v2.html
@@ -44,7 +44,12 @@
     padding: 24px 8px;
   }
   button { border: none; cursor: pointer; font: inherit; color: inherit; background: transparent; }
+  /* a11y: 仅键盘聚焦可见焦点环；触控点击不显示 */
   button:focus { outline: none; }
+  button:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
 
   /* 模拟手机外壳 · 实际端跑时去掉这层 */
   .device {
@@ -141,19 +146,29 @@
     font-weight: 500;
     color: var(--text-1);
     line-height: 1.55;
+    /* 长句 / 超长 token 安全 */
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    hyphens: auto;
   }
 
-  /* 当前句里的单词 · 可点 */
-  .word {
+  /* 当前句里的单词 · 真 <button>，可点 + 键盘可达 */
+  button.word {
     display: inline-block;
     padding: 1px 2px;
     margin: 0 -1px;
     border-radius: 3px;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    line-height: inherit;
     cursor: pointer;
     transition: background 120ms var(--ease);
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
   }
-  .word:active { background: var(--accent-soft); }
-  .word.selected {
+  button.word:active { background: var(--accent-soft); }
+  button.word[aria-pressed="true"] {
     background: var(--accent-soft);
     color: var(--accent);
     text-decoration: underline;
@@ -199,6 +214,45 @@
     gap: var(--space-2);
     z-index: 5;
   }
+  /* coach bar · 引导 + 进度 + 反馈一行 */
+  .coach-bar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px var(--space-4);
+    background: var(--bg-elevated);
+    border-top: 1px solid var(--border);
+    font-size: 12px;
+    color: var(--text-2);
+    line-height: 1.35;
+  }
+  .coach-bar .ico { font-size: 14px; flex-shrink: 0; }
+  .coach-bar .progress {
+    color: var(--text-3);
+    margin-right: 2px;
+  }
+  .coach-bar .copy { flex: 1; }
+  .coach-bar.recording { color: #c6463a; }
+
+  /* 横屏：max-height 较小时压缩 */
+  @media (orientation: landscape) and (max-height: 500px) {
+    .dock { padding-bottom: var(--space-2); }
+    .dock-row { gap: var(--space-1); }
+    .dock-btn { min-height: 44px; }
+    .coach-bar { display: none; }
+  }
+
+  /* ⚙ sheet 内常态披露行 */
+  .sheet-footer-note {
+    margin-top: 12px;
+    padding: 10px 12px;
+    background: var(--bg);
+    border-radius: var(--radius-sm);
+    font-size: 11px;
+    color: var(--text-3);
+    line-height: 1.5;
+  }
+  .sheet-footer-note a { color: var(--accent); text-decoration: underline; }
   .dock-row { display: flex; gap: var(--space-2); }
   .dock-btn {
     flex: 1;
@@ -225,9 +279,9 @@
     animation: rec-pulse 1s infinite;
   }
   .dock-btn.record.recording .label, .dock-btn.record.recording .ico { color: #fff; }
-  .dock-btn:disabled, .dock-btn.disabled {
+  /* aria-disabled 而非 disabled —— 保留 tabindex 与读屏可达 */
+  .dock-btn[aria-disabled="true"] {
     opacity: 0.45;
-    pointer-events: auto; /* 仍可点出 toast */
   }
   @keyframes rec-pulse {
     0%,100% { box-shadow: 0 0 0 0 rgba(198,70,58,0.4); }
@@ -336,28 +390,33 @@
     <!-- 句子列表 -->
     <div class="list" id="list"></div>
 
-    <!-- 底部 dock -->
+    <!-- 底部 dock：coach bar + 4 按钮 -->
     <div class="dock">
+      <div class="coach-bar" id="coachBar" role="status" aria-live="polite">
+        <span class="ico" aria-hidden="true">🎯</span>
+        <span class="progress" id="coachProgress">第 3/9 句</span>
+        <span class="copy" id="coachCopy">先听我读一次</span>
+      </div>
       <div class="dock-row">
-        <button class="dock-btn primary" onclick="onExplain()">
-          <span class="ico">💡</span>
-          <span class="label">解释</span>
-          <span class="sub" id="explainSub">整句</span>
+        <button class="dock-btn primary" id="explainBtn" onclick="onExplain()">
+          <span class="ico" aria-hidden="true">💡</span>
+          <span class="label" id="explainLabel">解释整句</span>
+          <span class="sub" id="explainSub"></span>
         </button>
-        <button class="dock-btn primary" onclick="onSpeak()">
-          <span class="ico">🔊</span>
-          <span class="label">发音</span>
-          <span class="sub" id="speakSub">整句</span>
+        <button class="dock-btn primary" id="speakBtn" onclick="onSpeak()">
+          <span class="ico" aria-hidden="true">🔊</span>
+          <span class="label" id="speakLabel">发音整句</span>
+          <span class="sub" id="speakSub"></span>
         </button>
       </div>
       <div class="dock-row">
-        <button class="dock-btn record" id="recBtn" onclick="onToggleRec()">
-          <span class="ico" id="recIco">🎤</span>
+        <button class="dock-btn record" id="recBtn" onclick="onToggleRec()" aria-pressed="false">
+          <span class="ico" id="recIco" aria-hidden="true">🎤</span>
           <span class="label" id="recLabel">录音</span>
-          <span class="sub" id="recSub">开始录</span>
+          <span class="sub" id="recSub" aria-live="polite">开始录</span>
         </button>
-        <button class="dock-btn disabled" id="playbackBtn" onclick="onPlayback()">
-          <span class="ico">▶</span>
+        <button class="dock-btn" id="playbackBtn" onclick="onPlayback()" aria-disabled="true" aria-label="回放，先录一段">
+          <span class="ico" aria-hidden="true">▶</span>
           <span class="label">回放</span>
           <span class="sub" id="playbackSub">无录音</span>
         </button>
@@ -404,6 +463,12 @@
         </span>
         <span class="sa-chev">›</span>
       </button>
+
+      <div class="sheet-footer-note">
+        ℹ︎ 关于复习评分 · 手机端暂不评分，本次练习不会进入 FSRS 复习计划；
+        如需评分请到桌面端，或关注
+        <a href="https://github.com/bob798/speakeasy/issues/26" target="_blank" rel="noopener">issue #26</a>。
+      </div>
     </div>
 
     <!-- toast -->
@@ -425,11 +490,16 @@
   ];
 
   let currentIdx = 2;
-  let selectedWord = null; // { word, idx } 或 null
+  let selectedWord = null; // { word, display } 或 null
   let recording = false;
+  let recordingSegIdx = null; // 录音绑定的句号；防止切句导致 blob 错位
   let hasRecording = false;
+  let hasPlayedBack = false;
+  let isPlayingTTS = false;
+  let practicedCount = 0; // 本轮已完成的句数（mock）
   let speed = '+0%';
   let engine = 'edge';
+  let lastRequestKey = null; // 异步响应去重
 
   const listEl = document.getElementById('list');
   const explainSub = document.getElementById('explainSub');
@@ -466,8 +536,19 @@
         // 当前句内点词时，不要触发选句
         if (e.target.closest('.word') || e.target.closest('.selected-bar')) return;
         if (i !== currentIdx) {
+          // 状态机约束：切句前停 TTS、确认录音中
+          if (recording) {
+            const ok = confirm('正在录音，停止并切换到这一句？');
+            if (!ok) return;
+            stopRecording(true /*discard*/);
+          }
+          stopTTS();
+          // 离开旧句视作"完成一句"（v0.1 用切句作完成信号；待 #26 评分后改为按 Good/Easy 计）
+          if (recordingSegIdx === null) practicedCount++;
           currentIdx = i;
           selectedWord = null;
+          hasRecording = false;
+          hasPlayedBack = false;
           render();
           scrollToCurrent();
         }
@@ -483,14 +564,15 @@
       const txt = document.createElement('div');
       txt.className = 'txt';
       if (isCurrent) {
-        // 拆词
+        // 拆词 → 真 <button class="word"> · 键盘可达 · aria-pressed 表选中
         tokenize(seg.text).forEach((tok) => {
           if (tok.type === 'word') {
-            const b = document.createElement('span');
+            const b = document.createElement('button');
             b.className = 'word';
-            if (selectedWord && selectedWord.word === tok.text.toLowerCase()) {
-              b.classList.add('selected');
-            }
+            b.type = 'button';
+            const isSel = selectedWord && selectedWord.word === tok.text.toLowerCase();
+            b.setAttribute('aria-pressed', isSel ? 'true' : 'false');
+            b.setAttribute('aria-label', `单词 ${tok.text}${isSel ? '（已选）' : ''}`);
             b.textContent = tok.text;
             b.onclick = (ev) => {
               ev.stopPropagation();
@@ -530,12 +612,46 @@
       listEl.appendChild(segEl);
     });
     updateSubs();
+    updateCoach();
   }
 
   function updateSubs() {
-    const sub = selectedWord ? selectedWord.display : '整句';
-    explainSub.textContent = sub;
-    speakSub.textContent = sub;
+    // 主标签随模式（句/词）切换；副标签仅在词模式下显示具体词面
+    const isWord = !!selectedWord;
+    document.getElementById('explainLabel').textContent = isWord ? '解释单词' : '解释整句';
+    document.getElementById('speakLabel').textContent   = isWord ? '发音单词' : '发音整句';
+    document.getElementById('explainSub').textContent = isWord ? selectedWord.display : '';
+    document.getElementById('speakSub').textContent   = isWord ? selectedWord.display : '';
+    // aria-label 完整描述
+    const targetA11y = isWord ? `当前作用对象 ${selectedWord.display}` : '整句';
+    document.getElementById('explainBtn').setAttribute('aria-label', `解释 · ${targetA11y}`);
+    document.getElementById('speakBtn').setAttribute('aria-label', `发音 · ${targetA11y}`);
+  }
+
+  // coach bar 状态机
+  function updateCoach() {
+    const total = segments.length;
+    const cb = document.getElementById('coachBar');
+    document.getElementById('coachProgress').textContent =
+      `第 ${currentIdx + 1}/${total} 句${practicedCount ? ' · 已完成 ' + practicedCount : ''}`;
+    cb.classList.remove('recording');
+
+    let copy;
+    if (recording) {
+      cb.classList.add('recording');
+      copy = '录音中 · 念完点停止';
+    } else if (isPlayingTTS) {
+      copy = '听着…';
+    } else if (hasRecording && hasPlayedBack) {
+      copy = '比一比，节奏对齐了吗';
+    } else if (hasRecording) {
+      copy = '收到了 · 回放听听自己';
+    } else if (selectedWord) {
+      copy = `解读 "${selectedWord.display}"`;
+    } else {
+      copy = '先听我读一次';
+    }
+    document.getElementById('coachCopy').textContent = copy;
   }
 
   function scrollToCurrent() {
@@ -544,53 +660,112 @@
     if (target) target.scrollIntoView({ block: 'center', behavior: 'smooth' });
   }
 
+  // 状态机原语
+  function stopTTS() {
+    // 真实端释放 audio + objectURL；mock 端只重置 flag
+    isPlayingTTS = false;
+    updateCoach();
+  }
+  function stopRecording(discard) {
+    recording = false;
+    recordingSegIdx = null;
+    const btn = document.getElementById('recBtn');
+    btn.classList.remove('recording');
+    btn.setAttribute('aria-pressed', 'false');
+    document.getElementById('recIco').textContent = '🎤';
+    document.getElementById('recLabel').textContent = '录音';
+    document.getElementById('recSub').textContent = (hasRecording && !discard) ? '重录' : '开始录';
+  }
+
   // dock 动作
   function onExplain() {
     const target = selectedWord ? `单词 "${selectedWord.display}"` : '整句';
-    toast(`💡 解释 ${target}（mock）`);
+    const key = `explain:${currentIdx}:${selectedWord?.word || '__'}:${Date.now()}`;
+    lastRequestKey = key;
+    // mock 200ms 异步 · 模拟 stale 响应防御
+    setTimeout(() => {
+      if (lastRequestKey !== key) return;
+      toast(`💡 解释 ${target}（mock）`);
+    }, 200);
   }
   function onSpeak() {
     const target = selectedWord ? `单词 "${selectedWord.display}"` : '整句';
-    toast(`🔊 发音 ${target}（mock · speed=${speed} engine=${engine}）`);
+    const key = `tts:${currentIdx}:${selectedWord?.word || '__'}:${Date.now()}`;
+    lastRequestKey = key;
+    stopTTS();
+    setTimeout(() => {
+      if (lastRequestKey !== key) return;
+      isPlayingTTS = true;
+      updateCoach();
+      toast(`🔊 发音 ${target}（mock · speed=${speed} engine=${engine}）`);
+      // mock 1.5s 播完
+      setTimeout(() => {
+        if (lastRequestKey !== key) return;
+        isPlayingTTS = false;
+        updateCoach();
+      }, 1500);
+    }, 200);
   }
   function onToggleRec() {
-    recording = !recording;
-    const btn = document.getElementById('recBtn');
-    const ico = document.getElementById('recIco');
-    const label = document.getElementById('recLabel');
-    const sub = document.getElementById('recSub');
     if (recording) {
-      btn.classList.add('recording');
-      ico.textContent = '⏹';
-      label.textContent = '停止';
-      sub.textContent = '录音中…';
-      toast('🎤 录音中');
-    } else {
-      btn.classList.remove('recording');
-      ico.textContent = '🎤';
-      label.textContent = '录音';
-      sub.textContent = '重录';
+      stopRecording(false);
       hasRecording = true;
+      hasPlayedBack = false;
       const pb = document.getElementById('playbackBtn');
-      pb.classList.remove('disabled');
+      pb.setAttribute('aria-disabled', 'false');
+      pb.setAttribute('aria-label', '回放录音');
       document.getElementById('playbackSub').textContent = '听自己';
+      updateCoach();
       toast('⏹ 已停止录音');
+    } else {
+      recording = true;
+      recordingSegIdx = currentIdx;
+      const btn = document.getElementById('recBtn');
+      btn.classList.add('recording');
+      btn.setAttribute('aria-pressed', 'true');
+      document.getElementById('recIco').textContent = '⏹';
+      document.getElementById('recLabel').textContent = '停止';
+      document.getElementById('recSub').textContent = '录音中…';
+      updateCoach();
+      toast('🎤 录音中');
     }
   }
   function onPlayback() {
-    if (!hasRecording) { toast('先录一段'); return; }
+    const pb = document.getElementById('playbackBtn');
+    if (pb.getAttribute('aria-disabled') === 'true') {
+      toast('先录一段');
+      return;
+    }
+    hasPlayedBack = true;
+    updateCoach();
     toast('▶ 回放（mock）');
   }
 
-  // sheet
+  // sheet · 焦点管理：打开时把焦点移到 sheet 内首个按钮；关闭还给 ⚙ 按钮
+  let _sheetTrigger = null;
   function openSheet() {
-    document.getElementById('sheetMask').classList.add('open');
-    document.getElementById('sheet').classList.add('open');
+    _sheetTrigger = document.activeElement;
+    const m = document.getElementById('sheetMask');
+    const s = document.getElementById('sheet');
+    m.classList.add('open');
+    s.classList.add('open');
+    // 屏蔽背景 a11y
+    document.querySelectorAll('.topbar, .list, .dock').forEach((el) => el.setAttribute('inert', ''));
+    // 焦点
+    const first = s.querySelector('button');
+    if (first) first.focus();
   }
   function closeSheet() {
     document.getElementById('sheetMask').classList.remove('open');
     document.getElementById('sheet').classList.remove('open');
+    document.querySelectorAll('.topbar, .list, .dock').forEach((el) => el.removeAttribute('inert'));
+    if (_sheetTrigger && typeof _sheetTrigger.focus === 'function') _sheetTrigger.focus();
   }
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && document.getElementById('sheet').classList.contains('open')) {
+      closeSheet();
+    }
+  });
   document.querySelectorAll('#speedPick button').forEach((b) => {
     b.onclick = () => {
       document.querySelectorAll('#speedPick button').forEach((x) => x.classList.remove('active'));
@@ -609,6 +784,17 @@
   render();
   // 等 render 之后再滚到当前句
   setTimeout(scrollToCurrent, 100);
+
+  // 首次进入：弹一次 FSRS 闭环披露 toast
+  const FSRS_NOTICE_KEY = 'v2:practice.fsrs_notice_seen';
+  try {
+    if (!localStorage.getItem(FSRS_NOTICE_KEY)) {
+      setTimeout(() => {
+        toast('ℹ︎ 手机端暂不记录复习评分，仍可正常练习');
+        localStorage.setItem(FSRS_NOTICE_KEY, '1');
+      }, 600);
+    }
+  } catch { /* ignore */ }
 </script>
 </body>
 </html>

--- a/mockups/practice-mobile-v2.html
+++ b/mockups/practice-mobile-v2.html
@@ -105,7 +105,9 @@
     flex: 1;
     overflow-y: auto;
     padding: var(--space-3) var(--space-4);
-    padding-bottom: 160px; /* 给 dock 让位 */
+    /* dock = coach bar(~36) + 2 行按钮(56×2 + 间隙 16 ≈ 128) + 上下 padding/safe-bottom(~32) ≈ 200px
+       多留 20px buffer，且确保最后一句完全不被毛玻璃 dock 遮挡 */
+    padding-bottom: 220px;
     scroll-behavior: smooth;
   }
   .seg {
@@ -304,9 +306,17 @@
     padding: var(--space-4) var(--space-4) calc(var(--space-4) + 12px);
     z-index: 21;
     transform: translateY(100%);
-    transition: transform 220ms var(--ease);
+    visibility: hidden;
+    pointer-events: none;
+    /* 关闭：transform 立即生效，visibility 在 transform 结束后再变 hidden */
+    transition: transform 220ms var(--ease), visibility 0ms 220ms;
   }
-  .sheet.open { transform: translateY(0); }
+  .sheet.open {
+    transform: translateY(0);
+    visibility: visible;
+    pointer-events: auto;
+    transition: transform 220ms var(--ease), visibility 0ms 0ms;
+  }
   .sheet h4 { margin: 0 0 var(--space-3); font-size: 14px; color: var(--text-2); }
   .row { display: flex; align-items: center; justify-content: space-between; padding: 10px 0; }
   .row label { font-size: 14px; color: var(--text-1); }


### PR DESCRIPTION
## Summary

把 Practice 发音练习页手机端 (`<768px`) 改造为「单手大拇指可达 + 教练状态条引导」的练习页。桌面端（`>= 768px`）不变。

**设计文档**：`docs/superpowers/specs/2026-05-12-practice-mobile-redesign.md`
**实现计划**：`docs/superpowers/plans/2026-05-12-practice-mobile-redesign.md`
**可点原型**：`mockups/practice-mobile-v2.html`（浏览器打开即体验）

## 主要变化

- 删除 📜 句子列表抽屉，列表直接在主页面滚动
- 顶栏只留一个 `⚙ 设置` 入口（语速 / TTS引擎 / 📖 BBC复习 / 🔄 重新导入 / ℹ︎ FSRS 说明）
- **新增 coach bar**（dock 顶部一行）：引导 + 进度 + 反馈（v1 静态规则推导，v2 接 LLM）
- **dock 两行四按钮**：💡 解释 / 🔊 发音 / 🎤 录音 / ▶ 回放
- **dock 主标签随选词模式切换**：默认 `解释整句`，选词后变 `解释单词`，副标签显示具体词
- **状态机约束完整**：切句停 TTS、录音中切句弹 confirm、异步 stale 响应丢弃、跨断点清理
- **a11y 规范**：真 `<button class="word">`、`:focus-visible` 焦点环、`aria-disabled` 假禁用、sheet `inert` 背景 + 焦点 trap、Esc 关 sheet
- **新建 3 个组件**：`useBreakpoint` / `useCoachBar` composables + `MobileActionDock.vue` / `MobileSentenceList.vue`
- **手机端暂无评分入口**：FSRS 闭环缺口通过首次 toast + ⚙ sheet 内 `ℹ︎ 关于复习评分` 常态披露（issue #26 跟进）

## 实现里程碑

| 阶段 | commit | 说明 |
|---|---|---|
| 规划 | `2c7c3b5`, `609bb03`, `88a3ef9` | spec + 产品视角修订 + 原型 + 实现计划 |
| P1-P2 | `740685c`, `107920b` | useBreakpoint + useCoachBar（含 8 个 vitest 单测） |
| P3-P4 | `b8bd231`, `efe9cef` | MobileActionDock + MobileSentenceList |
| P5 | `ad9313e`, `4d113d4` | Practice.vue 整合 + Codex 复审修订 |
| P6 | `3823489` | sheet 焦点管理 + Esc + inert |

## Verification

### Automated（已过）

- [x] `npm test` — 25/25 passed（含新增 useCoachBar.spec.js 8 个用例）
- [x] `npm run build` — clean, Practice bundle 12.74 kB gzip
- [x] `npm run size` — JS 99.45/200 kB · CSS 19.61/100 kB

### Manual（PR 合并前请走一遍）

iPhone 14 / 390×844 模拟器（Chrome DevTools mobile mode）：

- [ ] 首次进 Practice 弹一次 FSRS toast，再次进不弹（删 `localStorage['v2:practice.fsrs_notice_seen']` 重置）
- [ ] 当前句卡居中、其它句紧凑
- [ ] 点当前句某词 → 下划线 + 「已选: xxx」条 + dock 主标签变「解释单词 / 发音单词」+ coach bar 「解读 \"xxx\"」
- [ ] ✕ 清除选词 → 主标签回「解释整句」
- [ ] 🎤 录音 → 红色脉冲；停止后 ▶ 回放可点；coach bar 「回放听听自己」
- [ ] 回放后 coach bar 「比一比，节奏对齐了吗」
- [ ] 切到其它句 → 选词清零、coach bar 复位
- [ ] **录音中切句弹 confirm**：「停止并切换到这一句？」
- [ ] ⚙ → 弹底部 sheet → 改语速 → 关 sheet → 下次 🔊 用新语速
- [ ] Tab/Shift+Tab 焦点环可见（`:focus-visible`）
- [ ] sheet 打开后 Tab 在 sheet 内循环（inert 背景）
- [ ] Esc 关 sheet，焦点回到 ⚙ 按钮
- [ ] 横屏（844×390）dock 压成 44px 高、coach bar 隐藏
- [ ] DevTools resize 跨 767↔768 — 不残留状态、不报错
- [ ] 桌面端 ≥ 768px 布局不变

## Related issues

- #26 — 手机端评分流后续重做（FSRS 闭环恢复）

🤖 Generated with [Claude Code](https://claude.com/claude-code)