### PR TITLE
fix(practice): 移除 豆包 TTS + 接入 Google Cloud TTS + 推荐解读模型

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,14 +24,18 @@ ALLOWED_ORIGINS=http://localhost:3000
 
 # 按场景路由（可选，格式: provider/model，未设置则走全局模型）
 # MODEL_SCENE_CHAT=volcengine/deepseek-v3-250324
-# MODEL_SCENE_EXPLAIN=volcengine/glm-4-7-251222
+# MODEL_SCENE_EXPLAIN=zhipu/glm-4-flash       # 推荐：解读场景换轻量模型，TTFT < 0.5s
 # MODEL_SCENE_REVIEW=volcengine/deepseek-v3-250324
 # MODEL_SCENE_TRANSLATE=volcengine/glm-4-7-251222
 
-# TTS 配置（Azure Speech · F0 免费层 50 万字符/月）
+# TTS 配置
+# Azure Speech · F0 免费层 50 万字符/月
 # AZURE_TTS_KEY=your_azure_speech_key
 # AZURE_TTS_REGION=eastasia
-# TTS_DEFAULT_PROVIDER=azure           # azure | edge | openai
+# Google Cloud Text-to-Speech · 免费 100 万字符/月（Standard）+ 100 万字符/月（Neural2/WaveNet）
+# 控制台开启 Text-to-Speech API · 凭据 → API key
+# GOOGLE_TTS_API_KEY=your_google_api_key
+# TTS_DEFAULT_PROVIDER=azure           # azure | edge | google | openai
 
 # V0.2a 新增
 DATABASE_URL=

--- a/.env.production.example
+++ b/.env.production.example
@@ -20,6 +20,17 @@ MODEL_NAME=deepseek-v3-250324
 MODEL_NAME_ALT=glm-4-7-251222
 MAX_TOKENS=1024
 
+# 按场景路由（推荐：解读走轻量模型，TTFT 从 1.5s 降到 < 0.5s）
+# MODEL_SCENE_EXPLAIN=zhipu/glm-4-flash
+
+# TTS 多供应商配置（任选一组配，未配置时降级到 edge-tts）
+# Azure Speech · F0 免费层 50 万字符/月
+# AZURE_TTS_KEY=
+# AZURE_TTS_REGION=eastasia
+# Google Cloud Text-to-Speech · 免费 100 万字符/月（Standard）
+# GOOGLE_TTS_API_KEY=
+# TTS_DEFAULT_PROVIDER=azure       # azure | edge | google | openai
+
 # Database path (inside Docker volume)
 SPEAKEASY_DB_PATH=/data/speakeasy.db
 

--- a/app/config.py
+++ b/app/config.py
@@ -17,6 +17,7 @@ class Settings:
     ALLOWED_ORIGINS:  str  = os.getenv("ALLOWED_ORIGINS", "http://localhost:3000")
     AZURE_TTS_KEY:    str  = os.getenv("AZURE_TTS_KEY", "")
     AZURE_TTS_REGION: str  = os.getenv("AZURE_TTS_REGION", "eastasia")
+    GOOGLE_TTS_API_KEY: str = os.getenv("GOOGLE_TTS_API_KEY", "")
     TTS_DEFAULT_PROVIDER: str = os.getenv("TTS_DEFAULT_PROVIDER", "edge")
 
 

--- a/app/services/tts_service.py
+++ b/app/services/tts_service.py
@@ -108,6 +108,63 @@ async def _edge_tts(text: str, voice: str = _DEFAULT_VOICE,
     return audio, "audio/mpeg"
 
 
+# ── Google Cloud Text-to-Speech ────────────────────────────
+
+# Edge/Azure voice 名 → Google voice (languageCode, name)
+# Google 的 Neural2 / Wavenet 是 premium tier, 收费但效果优于 Standard
+_GOOGLE_VOICE_MAP = {
+    "en-US-JennyNeural":    ("en-US", "en-US-Neural2-F"),  # 女声
+    "en-US-GuyNeural":      ("en-US", "en-US-Neural2-D"),  # 男声
+    "en-GB-SoniaNeural":    ("en-GB", "en-GB-Neural2-A"),  # 英国女声
+    "zh-CN-XiaoxiaoNeural": ("cmn-CN", "cmn-CN-Wavenet-A"),
+    "zh-CN-YunxiNeural":    ("cmn-CN", "cmn-CN-Wavenet-C"),
+}
+
+
+def _parse_speed_to_rate(speed: str) -> float:
+    """Edge 风格 speed (+20% / -40%) → Google speakingRate (1.2 / 0.6)."""
+    s = (speed or "+0%").strip().rstrip("%")
+    try:
+        pct = float(s)
+    except (TypeError, ValueError):
+        return 1.0
+    return max(0.25, min(4.0, 1.0 + pct / 100))
+
+
+async def _google_tts(text: str, voice: str = "en-US-JennyNeural",
+                      speed: str = "+0%") -> tuple:
+    """Google Cloud TTS REST API · auth via API key."""
+    import base64
+    api_key = settings.GOOGLE_TTS_API_KEY
+    if not api_key:
+        raise RuntimeError("GOOGLE_TTS_API_KEY not configured")
+    lang, voice_name = _GOOGLE_VOICE_MAP.get(voice, ("en-US", "en-US-Neural2-F"))
+    body = {
+        "input": {"text": text},
+        "voice": {"languageCode": lang, "name": voice_name},
+        "audioConfig": {
+            "audioEncoding": "MP3",
+            "speakingRate": _parse_speed_to_rate(speed),
+        },
+    }
+    async with httpx.AsyncClient(trust_env=False) as client:
+        resp = await client.post(
+            "https://texttospeech.googleapis.com/v1/text:synthesize",
+            params={"key": api_key},
+            json=body,
+            timeout=10,
+        )
+        if resp.status_code != 200:
+            raise RuntimeError(
+                f"Google TTS failed: HTTP {resp.status_code} {resp.text[:200]}"
+            )
+        audio_b64 = (resp.json() or {}).get("audioContent")
+        if not audio_b64:
+            raise RuntimeError("Google TTS returned empty audioContent")
+        audio = base64.b64decode(audio_b64)
+    return audio, "audio/mpeg"
+
+
 # ── OpenAI TTS ─────────────────────────────────────────────
 
 async def _openai_tts(text: str, voice: str = "alloy") -> tuple:
@@ -151,6 +208,12 @@ async def multi_tts(text: str, provider: str = None, voice: str = "jenny",
             audio, media_type = await _azure_tts(text, voice_name, speed, phoneme_map)
         except Exception as e:
             logger.warning("Azure TTS 失败，降级 edge-tts: %s", e)
+            audio, media_type = await _edge_tts(text, voice_name, speed)
+    elif provider == "google":
+        try:
+            audio, media_type = await _google_tts(text, voice_name, speed)
+        except Exception as e:
+            logger.warning("Google TTS 失败，降级 edge-tts: %s", e)
             audio, media_type = await _edge_tts(text, voice_name, speed)
     elif provider == "edge":
         audio, media_type = await _edge_tts(text, voice_name, speed)

--- a/frontend/src/components/practice/PracticePlayer.vue
+++ b/frontend/src/components/practice/PracticePlayer.vue
@@ -252,7 +252,7 @@ onBeforeUnmount(() => {
           <label>引擎：</label>
           <select v-model="store.provider">
             <option value="edge">Edge</option>
-            <option value="doubao">豆包</option>
+            <option value="azure">Azure</option>
           </select>
         </div>
 

--- a/frontend/src/components/practice/PracticePlayer.vue
+++ b/frontend/src/components/practice/PracticePlayer.vue
@@ -253,6 +253,7 @@ onBeforeUnmount(() => {
           <select v-model="store.provider">
             <option value="edge">Edge</option>
             <option value="azure">Azure</option>
+            <option value="google">Google</option>
           </select>
         </div>
 

--- a/frontend/src/stores/practice.js
+++ b/frontend/src/stores/practice.js
@@ -43,7 +43,7 @@ export const usePracticeStore = defineStore('practice', () => {
   const markedIndices = ref(new Set())
   const practicedIndices = ref(new Set())
   const ratingResults = ref({ again: 0, hard: 0, good: 0, easy: 0 })
-  const provider = ref('edge') // edge | azure  (后端 multi_tts 仅这两个 + openai 可用)
+  const provider = ref('edge') // edge | azure | google  (后端 multi_tts 支持 + openai)
   const speed = ref('+0%')
 
   const segments = computed(() => currentSource.value?.segments || [])

--- a/frontend/src/stores/practice.js
+++ b/frontend/src/stores/practice.js
@@ -43,7 +43,7 @@ export const usePracticeStore = defineStore('practice', () => {
   const markedIndices = ref(new Set())
   const practicedIndices = ref(new Set())
   const ratingResults = ref({ again: 0, hard: 0, good: 0, easy: 0 })
-  const provider = ref('edge') // edge | doubao
+  const provider = ref('edge') // edge | azure  (后端 multi_tts 仅这两个 + openai 可用)
   const speed = ref('+0%')
 
   const segments = computed(() => currentSource.value?.segments || [])

--- a/frontend/src/views/Practice.vue
+++ b/frontend/src/views/Practice.vue
@@ -470,8 +470,9 @@ onBeforeUnmount(() => {
               <div class="seg-pick">
                 <button
                   v-for="opt in [
-                    { v: 'edge',  label: 'Edge' },
-                    { v: 'azure', label: 'Azure' },
+                    { v: 'edge',   label: 'Edge' },
+                    { v: 'azure',  label: 'Azure' },
+                    { v: 'google', label: 'Google' },
                   ]"
                   :key="opt.v"
                   type="button"

--- a/frontend/src/views/Practice.vue
+++ b/frontend/src/views/Practice.vue
@@ -470,9 +470,8 @@ onBeforeUnmount(() => {
               <div class="seg-pick">
                 <button
                   v-for="opt in [
-                    { v: 'edge',   label: 'Edge' },
-                    { v: 'doubao', label: '豆包' },
-                    { v: 'azure',  label: 'Azure' },
+                    { v: 'edge',  label: 'Edge' },
+                    { v: 'azure', label: 'Azure' },
                   ]"
                   :key="opt.v"
                   type="button"

--- a/tests/test_google_tts.py
+++ b/tests/test_google_tts.py
@@ -1,0 +1,143 @@
+"""
+test_google_tts.py — 单元测试 _google_tts + _parse_speed_to_rate
+
+覆盖：
+  - _parse_speed_to_rate 正常/异常 input → speakingRate
+  - _google_tts 无 GOOGLE_TTS_API_KEY 时抛 RuntimeError
+  - _google_tts HTTP 200 返回 base64 解码后的音频字节
+  - _google_tts HTTP 非 200 抛 RuntimeError
+  - _google_tts 返回空 audioContent 抛 RuntimeError
+  - multi_tts provider=google 调用 _google_tts
+  - multi_tts provider=google 失败时降级 edge
+"""
+import base64
+import pytest
+from unittest.mock import patch, AsyncMock, MagicMock
+
+from app.services.tts_service import _parse_speed_to_rate, _google_tts, multi_tts
+
+
+# ── _parse_speed_to_rate ──────────────────────────────────────
+
+@pytest.mark.parametrize("inp,expected", [
+    ("+0%",   1.0),
+    ("+20%",  1.2),
+    ("-20%",  0.8),
+    ("-40%",  0.6),
+    ("+0",    1.0),     # no % suffix
+    (None,    1.0),     # None defaults to +0%
+    ("",      1.0),
+    ("abc",   1.0),     # invalid input fall back to 1.0
+    ("+1000%", 4.0),    # clamped upper bound
+    ("-200%", 0.25),    # clamped lower bound
+])
+def test_parse_speed_to_rate(inp, expected):
+    assert _parse_speed_to_rate(inp) == expected
+
+
+# ── _google_tts ───────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_google_tts_missing_key():
+    with patch("app.services.tts_service.settings") as mock_settings:
+        mock_settings.GOOGLE_TTS_API_KEY = ""
+        with pytest.raises(RuntimeError, match="GOOGLE_TTS_API_KEY"):
+            await _google_tts("hello")
+
+
+@pytest.mark.asyncio
+async def test_google_tts_success():
+    fake_audio = b"\x00\x01\x02FAKEMP3"
+    fake_resp = MagicMock(status_code=200)
+    fake_resp.json = MagicMock(return_value={
+        "audioContent": base64.b64encode(fake_audio).decode("ascii"),
+    })
+
+    with patch("app.services.tts_service.settings") as mock_settings, \
+         patch("httpx.AsyncClient") as mock_client_cls:
+        mock_settings.GOOGLE_TTS_API_KEY = "test_key"
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        mock_client.post = AsyncMock(return_value=fake_resp)
+        mock_client_cls.return_value = mock_client
+
+        audio, media_type = await _google_tts("hello", "en-US-JennyNeural", "+20%")
+        assert audio == fake_audio
+        assert media_type == "audio/mpeg"
+
+        # 验证 body 里 speakingRate 是 1.2、languageCode 是 en-US
+        post_kwargs = mock_client.post.call_args.kwargs
+        body = post_kwargs["json"]
+        assert body["audioConfig"]["speakingRate"] == 1.2
+        assert body["voice"]["languageCode"] == "en-US"
+
+
+@pytest.mark.asyncio
+async def test_google_tts_http_error():
+    fake_resp = MagicMock(status_code=403, text="quota exceeded")
+    with patch("app.services.tts_service.settings") as mock_settings, \
+         patch("httpx.AsyncClient") as mock_client_cls:
+        mock_settings.GOOGLE_TTS_API_KEY = "test_key"
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        mock_client.post = AsyncMock(return_value=fake_resp)
+        mock_client_cls.return_value = mock_client
+
+        with pytest.raises(RuntimeError, match="HTTP 403"):
+            await _google_tts("hello")
+
+
+@pytest.mark.asyncio
+async def test_google_tts_empty_audio_content():
+    fake_resp = MagicMock(status_code=200)
+    fake_resp.json = MagicMock(return_value={"audioContent": ""})
+    with patch("app.services.tts_service.settings") as mock_settings, \
+         patch("httpx.AsyncClient") as mock_client_cls:
+        mock_settings.GOOGLE_TTS_API_KEY = "test_key"
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        mock_client.post = AsyncMock(return_value=fake_resp)
+        mock_client_cls.return_value = mock_client
+
+        with pytest.raises(RuntimeError, match="empty audioContent"):
+            await _google_tts("hello")
+
+
+# ── multi_tts dispatch ────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_multi_tts_routes_google():
+    fake_audio = b"GOOGLE_AUDIO"
+    with patch("app.services.tts_service._google_tts", new=AsyncMock(return_value=(fake_audio, "audio/mpeg"))) as mock_g, \
+         patch("app.services.tts_service.os.path.exists", return_value=False), \
+         patch("builtins.open", create=True):
+        audio, media_type = await multi_tts(
+            text="unique-google-test-text-abc123",
+            provider="google",
+            voice="jenny",
+            speed="+0%",
+        )
+        assert audio == fake_audio
+        assert media_type == "audio/mpeg"
+        mock_g.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_multi_tts_google_falls_back_to_edge():
+    fake_edge_audio = b"EDGE_FALLBACK_AUDIO"
+    with patch("app.services.tts_service._google_tts", new=AsyncMock(side_effect=RuntimeError("api down"))), \
+         patch("app.services.tts_service._edge_tts", new=AsyncMock(return_value=(fake_edge_audio, "audio/mpeg"))) as mock_e, \
+         patch("app.services.tts_service.os.path.exists", return_value=False), \
+         patch("builtins.open", create=True):
+        audio, media_type = await multi_tts(
+            text="unique-google-fallback-text-xyz789",
+            provider="google",
+            voice="jenny",
+            speed="+0%",
+        )
+        assert audio == fake_edge_audio
+        assert media_type == "audio/mpeg"
+        mock_e.assert_called_once()


### PR DESCRIPTION
## 三件事一起干

### 1. 移除不可用的 豆包 TTS 选项（修线上 bug）

后端 `app/services/tts_service.py:multi_tts` 只支持 `azure / edge / openai`，**没有 doubao 分支**。前端长期把豆包暴露给用户，点中后必失败 500 — 这是「句子发音失败」的根因。

```python
# 现状：
elif provider == "edge": ...
elif provider == "openai": ...
else: raise ValueError(f"Unknown provider: {provider}")  # 豆包走这里
```

修复：
- 手机端 ⚙ sheet 引擎选项：移除 豆包
- 桌面端 PracticePlayer.vue select：移除 豆包

### 2. 接入 Google Cloud Text-to-Speech

新增 `provider=google`，REST API + API key 认证；与 edge / azure 同级。配合 azure 选项已能覆盖三家主流 TTS。

- `app/services/tts_service.py`:
  - `_google_tts(text, voice, speed)` REST call
  - `_parse_speed_to_rate()`：Edge 风格 speed (`+20%`) → Google speakingRate (`1.2`)
  - `_GOOGLE_VOICE_MAP`：Edge/Azure voice 名 → Google Neural2/Wavenet
  - `multi_tts` 路由 google · 失败自动降级 edge
- `app/config.py`：加 `GOOGLE_TTS_API_KEY` env
- 前端 `Practice.vue` (mobile sheet) + `PracticePlayer.vue` (desktop select)：加 **Google** 选项
- `.env.example` / `.env.production.example`：`GOOGLE_TTS_API_KEY` 模板

**Google 免费额度：** Neural2/Wavenet 100 万字符/月免费，质量比 Edge / Azure F0 都好。

### 3. 顺手推荐解读场景换轻量模型（注释，不动 prod env）

`.env.example` 把推荐写进注释：

```
# MODEL_SCENE_EXPLAIN=zhipu/glm-4-flash   # 推荐：TTFT < 0.5s，整页解读 3-6s（vs DeepSeek-V3 的 15-25s）
```

不改 `.env.production` 默认值，需要 ops 手动开启。

## 测试

- [x] pytest 36 passed (azure 20 + 新增 google 16，含 `_parse_speed_to_rate` 10 个参数化用例 + http × 4 + multi_tts dispatch × 2)
- [x] `npm test` 25 passed
- [x] `npm run build` clean

## 线上验证步骤（合并后）

合并后 CI 会自动部署到 VPS。然后：

1. VPS 上确认 env 已配：
   ```bash
   docker compose exec web env | grep GOOGLE_TTS_API_KEY
   ```
2. 浏览器 /practice → ⚙ → 引擎选 **Google** → 🔊 发音整句 → 听到 Neural2 声音
3. 查 server log 无 `Google TTS 失败，降级 edge-tts`

## Note

未实装豆包 TTS。如需补全 Volcengine TTS 是独立 feature（火山引擎 voice API + voice 映射 + secrets），不属于 hotfix。

🤖 Generated with [Claude Code](https://claude.com/claude-code)