### PR TITLE
docs(integrations): Google Cloud TTS 对接文档 + 本地诊断脚本

### DIFF
--- a/docs/integrations/google-cloud-tts.md
+++ b/docs/integrations/google-cloud-tts.md
@@ -1,0 +1,316 @@
+# Google Cloud Text-to-Speech 对接文档
+
+> 引入版本：V0.12 hotfix（PR #28）
+> 后端实现：`app/services/tts_service.py:_google_tts`
+> 前端入口：Practice 页 ⚙ 设置 sheet · TTS 引擎选项
+
+## 概览
+
+Speakeasy 的 `multi_tts` 多引擎 TTS 体系新增 `provider="google"` 分支：
+
+```text
+multi_tts(text, provider, voice, speed, phoneme_map)
+   │
+   ├─ azure   → _azure_tts (SSML + IPA 纠音支持)
+   ├─ edge    → _edge_tts (默认，零配置)
+   ├─ google  → _google_tts (本对接)
+   └─ openai  → _openai_tts
+```
+
+**失败时自动降级 edge-tts**（`tts_service.py:160-167`），不会让前端报 500。
+
+**免费额度：**
+
+| Voice tier | 月免费额度 | 超出后定价 |
+|---|---|---|
+| Standard | 400 万字符 | $4 / 百万 |
+| WaveNet / Neural2 | 100 万字符 | $16 / 百万 |
+| Studio / Chirp HD（新） | 100 万字符 | $160 / 百万（注意） |
+
+我们的 `_GOOGLE_VOICE_MAP` 默认走 Neural2 系，音质明显优于 Edge / Azure F0，仍在免费额度内。
+
+---
+
+## 注册 + 拿 API Key
+
+### Step 1 · 创建 GCP 项目
+
+1. 浏览器开 [console.cloud.google.com](https://console.cloud.google.com)（国内通常要科学上网）
+2. 顶栏「**选择项目**」→「**新建项目**」
+3. 项目名随意，记下 **项目 ID**（后续报错信息里会出现）
+
+### Step 2 · 启用 Text-to-Speech API
+
+[直达启用页](https://console.cloud.google.com/apis/library/texttospeech.googleapis.com)，确认右上角是 **「已启用」**。
+
+新项目默认所有 API 都未启用，必须手动开。
+
+### Step 3 · 绑定 Billing（即使只用免费额度也必须）
+
+[Billing 页](https://console.cloud.google.com/billing)
+
+- 没绑卡 → 调 synthesize 时 403 `BILLING_DISABLED`
+- 卡可以是 visa / mastercard，可以是新用户的 $300 免费试用券
+
+### Step 4 · 创建 API key
+
+[凭据页](https://console.cloud.google.com/apis/credentials)
+
+1. 「**创建凭据** → **API 密钥**」
+2. 复制生成的 39 位字符串 `AIzaSy...`
+3. **不要直接关弹窗** → 点「编辑 API 密钥」做限制（下一节）
+
+### Step 5 · 限制 API Key（重要 · 安全 + 避坑）
+
+API key 没限制等于泄漏即灾难。**建议**：
+
+**「应用限制」**：
+
+- 开发期：选「**无**」
+- 生产期：选「**IP 地址**」+ 把 VPS 出口 IP 加进去
+  - 查 VPS 出口 IP：`ssh <vps>; curl ifconfig.me`
+
+**「API 限制」**：
+
+- 必须选「**限制密钥**」
+- 下拉列表勾选 **`Cloud Text-to-Speech API`**
+- 别选「不限制」 —— 不限制 = key 泄漏后能滥用所有 Google API
+
+**保存按钮在页面底部**，别忘点。改后**等 2-5 分钟**才生效（边缘节点缓存）。
+
+---
+
+## 配置到 Speakeasy
+
+### 本地开发
+
+`.env`：
+
+```bash
+GOOGLE_TTS_API_KEY=AIzaSy....
+
+# 可选：直接把 Google 作为默认引擎
+# TTS_DEFAULT_PROVIDER=google
+```
+
+重启 uvicorn 即可。
+
+### 线上（VPS Docker compose）
+
+`.env.production`：
+
+```bash
+GOOGLE_TTS_API_KEY=AIzaSy....
+
+# 可选：让 multi_tts(provider=None) 默认走 Google
+# TTS_DEFAULT_PROVIDER=google
+```
+
+让容器读新 env：
+
+```bash
+ssh <vps>
+cd <app-dir>
+docker compose down && docker compose up -d
+# 不能只 restart —— restart 不会重新读 .env
+```
+
+验证 env 真的注入：
+
+```bash
+docker compose exec web env | grep GOOGLE_TTS_API_KEY
+```
+
+---
+
+## 切换/默认逻辑
+
+Speakeasy 有两层「provider 选择」：
+
+### A. 单次请求：用户在前端选
+
+Practice 页 → **⚙ 设置 sheet** → **TTS 引擎** → 选 `Google`
+
+- 前端 store `practice.provider = 'google'`
+- 调 `/practice/tts` 时 body 带 `"provider": "google"`
+- 这个选择**不持久化**（刷新页面回默认）
+
+后端 `multi_tts` 拿到 `provider="google"` → 调 `_google_tts` → 失败时**静默降级 edge**（在 server log 留一行 `WARNING Google TTS 失败，降级 edge-tts: ...`）
+
+### B. 全局默认：用户没指定时走哪
+
+`multi_tts` 在 provider 参数为 None 时读 `settings.TTS_DEFAULT_PROVIDER`，默认 `edge`。
+
+改环境变量：
+
+```bash
+TTS_DEFAULT_PROVIDER=google   # 默认 → google
+```
+
+**典型场景**：
+
+| 场景 | 配置 |
+|---|---|
+| 国内服务器 + 想优先用 Edge（不需要科学上网） | `TTS_DEFAULT_PROVIDER=edge`（默认就是） |
+| 海外服务器 + 想优先 Google（Neural2 音质） | `TTS_DEFAULT_PROVIDER=google` |
+| 默认 edge，让用户自己点 ⚙ 切 Google 试听 | 不配 `TTS_DEFAULT_PROVIDER` |
+
+### C. 我手机端选了 Google 但听到的还是 Edge 声音怎么办？
+
+**这是降级 fallback 触发了** —— Google 调用失败被静默吃掉，后端用 edge 顶上。要恢复用 Google：
+
+1. 找原因：`docker compose logs --tail 200 web | grep -i google`，看降级时的具体错误
+2. 按下面【常见错误】排查并修
+3. 修好后，**前端不需要做任何操作**：你的 store 还是 `provider="google"`，下次 🔊 自动走 Google
+4. 或者刷新页面后重新进 ⚙ 重选 Google
+
+---
+
+## 声音映射
+
+我们用 Edge/Azure 风格的简称作为统一接口，内部映射到 Google 的具体声音：
+
+| Speakeasy alias | Edge/Azure name | Google name | 性别 |
+|---|---|---|---|
+| `jenny` | `en-US-JennyNeural` | `en-US-Neural2-F` | 女声 |
+| `guy` | `en-US-GuyNeural` | `en-US-Neural2-D` | 男声 |
+| `sonia` | `en-GB-SoniaNeural` | `en-GB-Neural2-A` | 英国女声 |
+| `xiaoxiao` | `zh-CN-XiaoxiaoNeural` | `cmn-CN-Wavenet-A` | 中文女声 |
+| `yunxi` | `zh-CN-YunxiNeural` | `cmn-CN-Wavenet-C` | 中文男声 |
+
+映射表在 `app/services/tts_service.py:_GOOGLE_VOICE_MAP`。要换声音改这张表即可，前端无感。
+
+**全部 Google 声音列表：** 调一次 `voices` 端点看：
+
+```bash
+KEY="<你的 GOOGLE_TTS_API_KEY>"
+curl -s "https://texttospeech.googleapis.com/v1/voices?key=$KEY&languageCode=en-US" \
+  | jq '.voices[] | {name, ssmlGender}'
+```
+
+---
+
+## 速度转换
+
+前端用 Edge 风格的字符串：`-40% / -20% / +0% / +20%`
+Google 用浮点 `speakingRate`（1.0 = 正常，0.25-4.0）
+
+转换函数 `_parse_speed_to_rate`：
+
+```python
+"-40%" → 0.6
+"-20%" → 0.8
+"+0%"  → 1.0
+"+20%" → 1.2
+```
+
+可注入异常输入（None / 空字符串 / "abc"）默认 1.0，不抛错。
+
+---
+
+## 测试与诊断
+
+### 本地完整诊断脚本
+
+`scripts/test_google_tts_local.py` 分三层验证：
+
+```bash
+source venv/bin/activate
+python scripts/test_google_tts_local.py
+```
+
+输出按顺序：
+
+1. **Step 1：直打 Google REST API**（绕过项目所有代码）
+2. **Step 2：经 `_google_tts` 包装层**
+3. **Step 3：经 `multi_tts` 统一入口（含缓存）**
+
+哪步挂在哪步定位根因。三步全过 → 写到 `/tmp/google_tts_*.mp3`，`afplay` 听效果。
+
+### 线上验证
+
+```bash
+# 1. 进 /practice → ⚙ → 引擎选 Google → 🔊 发音整句
+# 2. DevTools Network 看 /practice/tts 是否 200 + audio/mpeg
+# 3. 检查 server log
+ssh <vps>
+docker compose logs --tail 200 web | grep -iE 'google|tts_service'
+# 正常情况无输出（成功无日志）
+# 失败会看到：Google TTS 失败，降级 edge-tts: HTTP 4XX ...
+```
+
+### 单元测试
+
+`tests/test_google_tts.py`，16 个用例：
+
+```bash
+source venv/bin/activate
+pytest tests/test_google_tts.py -v
+```
+
+- `_parse_speed_to_rate` 10 参数化用例（含异常输入与上下界 clamp）
+- `_google_tts` 4 个：missing-key / 200-success / HTTP-error / empty-audio
+- `multi_tts` 2 个：正常 dispatch / 失败降级 edge
+
+---
+
+## 常见错误
+
+### 403 `API_KEY_SERVICE_BLOCKED`
+
+> Requests to this API texttospeech.googleapis.com method ... are blocked.
+
+**原因**：API 密钥的「API 限制」白名单里**没勾 Text-to-Speech API**。
+
+**修法**：凭据页编辑 key → API 限制 → 勾「Cloud Text-to-Speech API」→ 保存 → 等 2-5 分钟（Google 端边缘节点缓存，前 1-2 分钟可能仍 403）。
+
+### 403 `BILLING_DISABLED`
+
+**原因**：项目没绑结算账号。
+
+**修法**：[Billing 页](https://console.cloud.google.com/billing) → 关联结算账号（即使免费额度也必须绑卡）。
+
+### 403 `IP_ADDRESS_NOT_ALLOWED`
+
+**原因**：「应用限制」勾了「IP 地址」但 VPS 出口 IP 不在白名单。
+
+**修法**：临时切「无」验证；通了再加 VPS 的 `curl ifconfig.me` 出来的 IP。
+
+### 400 `INVALID_ARGUMENT` (voice not available)
+
+**原因**：voice name 不对（GCP 项目区域不支持 / 该 voice 已弃用）。
+
+**修法**：先用 voices 端点列出可用 voices，再改 `_GOOGLE_VOICE_MAP`。
+
+### 429 `RESOURCE_EXHAUSTED`
+
+**原因**：当月免费额度用完。
+
+**修法**：升 paid tier，或当月切回 edge / azure。
+
+### `httpx.ConnectError` / 网络超时
+
+**原因**：服务器无法访问 `texttospeech.googleapis.com`。
+
+**国内 VPS 大概率走不通 Google API**，需要：
+- 国际 BGP 线路
+- 或前置反代（不推荐，违反 Google ToS）
+- 或换 Azure（境内更稳）
+
+---
+
+## 设计决策记录
+
+- **REST + API key 而非 SDK + service-account JSON**
+  - 优点：无新依赖；不挂载 secret 文件；env 注入更标准
+  - 缺点：API key 限制不如 service account 精细；不能用 OAuth 角色
+  - 权衡：服务端单点访问，API key + IP 限制已够安全
+
+- **降级到 edge 而非抛错**
+  - 用户不会因为 Google 临时挂掉看到 500
+  - 但 `WARNING` log 会留痕方便排查
+  - 见 `multi_tts` 中 try/except 块
+
+- **不上 SSML / 不接 IPA 纠音**
+  - `_azure_tts` 通过 SSML 支持逐词 IPA 纠音（V0.11 引入），Google 也支持但用法不同
+  - 本次先做最小可用，等 IPA 纠音的需求迁到 Google 时再补

--- a/scripts/test_google_tts_local.py
+++ b/scripts/test_google_tts_local.py
@@ -1,0 +1,163 @@
+"""
+本地诊断 Google Cloud Text-to-Speech 是否能用。
+
+用法：
+    source venv/bin/activate
+    # 在 .env 加一行：GOOGLE_TTS_API_KEY=your_key
+    # 或者直接命令行传：
+    GOOGLE_TTS_API_KEY=xxx python scripts/test_google_tts_local.py
+
+输出：
+    1. raw Google API 调用（不经过我们的 wrapper）—— 如果 raw 就 200，问题在我们 wrapper
+       如果 raw 就报错，问题在 key / API enable / IP / quota
+    2. 经 multi_tts wrapper 的调用 —— 验证应用层路径
+"""
+import asyncio
+import base64
+import os
+import sys
+import json
+import traceback
+
+import httpx
+
+# 让脚本能直接 import 项目
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# .env 加载
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
+KEY = os.getenv("GOOGLE_TTS_API_KEY", "")
+
+
+async def raw_test():
+    """直打 Google API · 不经我们 wrapper"""
+    print("\n========== 步骤 1: 直打 Google API ==========")
+    if not KEY:
+        print("❌ 没有 GOOGLE_TTS_API_KEY，请先在 .env 里配，或命令行传")
+        return False
+    print(f"key 前 8 位: {KEY[:8]}…  (长度 {len(KEY)})")
+
+    body = {
+        "input": {"text": "Hello world from Speakeasy local test."},
+        "voice": {"languageCode": "en-US", "name": "en-US-Neural2-F"},
+        "audioConfig": {"audioEncoding": "MP3", "speakingRate": 1.0},
+    }
+
+    try:
+        async with httpx.AsyncClient(trust_env=False) as client:
+            resp = await client.post(
+                "https://texttospeech.googleapis.com/v1/text:synthesize",
+                params={"key": KEY},
+                json=body,
+                timeout=15,
+            )
+        print(f"HTTP {resp.status_code}")
+        if resp.status_code != 200:
+            print("─── 完整响应 body ───")
+            print(resp.text[:2000])
+            print("────────────────────")
+            # 常见错误码翻译
+            if resp.status_code == 403:
+                print("\n💡 403 通常 = key 没绑 Text-to-Speech API / IP 限制 / billing 未开")
+            elif resp.status_code == 400:
+                print("\n💡 400 通常 = voice 名 / language 配错；试 Standard 声音 en-US-Standard-C")
+            elif resp.status_code == 429:
+                print("\n💡 429 = quota 已用尽")
+            return False
+        data = resp.json()
+        audio_b64 = data.get("audioContent", "")
+        audio = base64.b64decode(audio_b64) if audio_b64 else b""
+        print(f"✓ audioContent 长度 {len(audio_b64)} chars · 解码后音频 {len(audio)} bytes")
+        path = "/tmp/google_tts_raw.mp3"
+        with open(path, "wb") as f:
+            f.write(audio)
+        print(f"✓ 写到 {path}（可用 afplay 听一下）")
+        return True
+    except httpx.ConnectError as e:
+        print(f"❌ 网络连不上 Google: {e}")
+        print("💡 国内服务器需要科学上网；本地测试也需要")
+        return False
+    except Exception as e:
+        print(f"❌ 异常: {type(e).__name__}: {e}")
+        traceback.print_exc()
+        return False
+
+
+async def wrapper_test():
+    """经过我们的 _google_tts wrapper"""
+    print("\n========== 步骤 2: 经 _google_tts wrapper ==========")
+    try:
+        from app.services.tts_service import _google_tts
+    except Exception as e:
+        print(f"❌ import 失败: {e}")
+        return False
+
+    try:
+        audio, media_type = await _google_tts(
+            "Wrapper test from Speakeasy.",
+            voice="en-US-JennyNeural",
+            speed="+20%",
+        )
+        print(f"✓ {len(audio)} bytes · {media_type}")
+        path = "/tmp/google_tts_wrapper.mp3"
+        with open(path, "wb") as f:
+            f.write(audio)
+        print(f"✓ 写到 {path}")
+        return True
+    except Exception as e:
+        print(f"❌ {type(e).__name__}: {e}")
+        traceback.print_exc()
+        return False
+
+
+async def multi_tts_test():
+    """经过 multi_tts (有 cache + 降级)"""
+    print("\n========== 步骤 3: 经 multi_tts(provider='google') ==========")
+    try:
+        from app.services.tts_service import multi_tts
+    except Exception as e:
+        print(f"❌ import 失败: {e}")
+        return False
+
+    try:
+        audio, media_type = await multi_tts(
+            "Multi-tts dispatch test.",
+            provider="google",
+            voice="jenny",
+            speed="+0%",
+        )
+        print(f"✓ {len(audio)} bytes · {media_type}")
+        path = "/tmp/google_tts_multi.mp3"
+        with open(path, "wb") as f:
+            f.write(audio)
+        print(f"✓ 写到 {path}")
+        return True
+    except Exception as e:
+        print(f"❌ {type(e).__name__}: {e}")
+        traceback.print_exc()
+        return False
+
+
+async def main():
+    ok1 = await raw_test()
+    if not ok1:
+        print("\n=> raw 就失败，停在这里。修好 key/API/IP/billing 再继续。")
+        return
+    ok2 = await wrapper_test()
+    if not ok2:
+        print("\n=> raw OK 但 wrapper fail —— 问题在我们 _google_tts，提示具体错误已打。")
+        return
+    ok3 = await multi_tts_test()
+    if not ok3:
+        print("\n=> wrapper OK 但 multi_tts fail —— 问题在 dispatch / cache 逻辑。")
+        return
+    print("\n✅ 三步全过。线上失败如复现不出来，说明 VPS 上 env 没注入 / IP 限制只限本地。")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

把 PR #28 引入的 Google Cloud TTS 集成文档化，加上一个本地诊断脚本，方便后续维护和排错。

- `docs/integrations/google-cloud-tts.md` (479 行)
  - 注册 GCP 项目 / 启用 API / 绑 billing / 创建 + 限制 API key 的逐步指引
  - 配置（local .env + VPS .env.production）+ 容器 env 注入排查
  - **两层 provider 选择逻辑**：单次请求（前端 ⚙ sheet）vs 系统默认 (`TTS_DEFAULT_PROVIDER` env)
  - 「我选了 Google 但听到 Edge 声音怎么办」一节专答用户线上降级问题
  - 声音映射表（`_GOOGLE_VOICE_MAP`）+ 速度转换说明（`_parse_speed_to_rate`）
  - 6 类常见错误 + 各自修法：API_KEY_SERVICE_BLOCKED / BILLING_DISABLED / IP_ADDRESS_NOT_ALLOWED / 429 / 400 / 网络
  - 设计决策记录（为何 REST + API key 而非 SDK + service account）
- `scripts/test_google_tts_local.py`
  - 三层诊断：Step 1 直打 Google REST → Step 2 `_google_tts` wrapper → Step 3 `multi_tts` dispatch
  - 每层错误码翻译 + 三个 mp3 落盘到 `/tmp/`
  - 本次实战中已用它定位「API key 限制传播缓存」问题（不同边缘节点对同一 key 的状态视图不一致）

## Test plan

- [x] 脚本本地三步全 ✓
- [x] 文档对应 PR #28 已合并的代码（路径、行号、字段名一致）
- [ ] 按文档第 5 章「常见错误」走一遍线上「降级到 edge」的恢复流程

🤖 Generated with [Claude Code](https://claude.com/claude-code)