### PR TITLE
chore(tts): 加强 TTS 链路日志（rid + traceback）

### DIFF
--- a/app/routers/practice.py
+++ b/app/routers/practice.py
@@ -351,24 +351,49 @@ class PracticeTTSRequest(BaseModel):
 @router.post("/practice/tts")
 async def practice_tts(req: PracticeTTSRequest):
     """Multi-source TTS with disk caching"""
+    import time
+    import uuid
+    import logging
+    tts_logger = logging.getLogger("practice.tts")
+    rid = uuid.uuid4().hex[:8]
+    t0 = time.time()
+    text_len = len(req.text or "")
+    tts_logger.info(
+        "[tts %s] start provider=%s voice=%s speed=%s text_len=%d preview=%r",
+        rid, req.provider or "(default)", req.voice, req.speed, text_len,
+        (req.text or "")[:40],
+    )
+
     if req.provider == "original":
         if req.segment_path and os.path.exists(req.segment_path):
             with open(req.segment_path, "rb") as f:
-                return Response(content=f.read(), media_type="audio/mpeg")
+                data = f.read()
+            tts_logger.info("[tts %s] ok provider=original bytes=%d ms=%d",
+                            rid, len(data), int((time.time()-t0)*1000))
+            return Response(content=data, media_type="audio/mpeg")
+        tts_logger.warning("[tts %s] 404 segment_path missing: %s", rid, req.segment_path)
         raise HTTPException(404, "Original audio segment not found")
 
     if not req.text:
+        tts_logger.warning("[tts %s] 400 empty text", rid)
         raise HTTPException(400, "text is required")
 
     try:
         provider = req.provider if req.provider else None  # None = 使用默认
         audio, media_type = await multi_tts(req.text, provider, req.voice, req.speed)
+        tts_logger.info(
+            "[tts %s] ok provider=%s bytes=%d ms=%d",
+            rid, req.provider or "(default)", len(audio),
+            int((time.time()-t0)*1000),
+        )
         return Response(
             content=audio,
             media_type=media_type,
             headers={"Cache-Control": "public, max-age=3600"},
         )
     except ValueError as e:
+        tts_logger.warning("[tts %s] 400 ValueError: %s", rid, e)
         raise HTTPException(400, str(e))
     except Exception as e:
+        tts_logger.exception("[tts %s] 503 %s: %s", rid, type(e).__name__, e)
         raise HTTPException(503, f"TTS failed: {e}")

--- a/app/services/tts_service.py
+++ b/app/services/tts_service.py
@@ -191,6 +191,7 @@ async def _openai_tts(text: str, voice: str = "alloy") -> tuple:
 async def multi_tts(text: str, provider: str = None, voice: str = "jenny",
                     speed: str = "+0%", phoneme_map: dict = None) -> tuple:
     """Multi-source TTS with disk caching. Returns (audio_bytes, media_type)."""
+    import time
     if provider is None:
         provider = settings.TTS_DEFAULT_PROVIDER
 
@@ -199,21 +200,26 @@ async def multi_tts(text: str, provider: str = None, voice: str = "jenny",
     cache_path = os.path.join(TTS_CACHE_DIR, f"{cache_key}.mp3")
     if os.path.exists(cache_path):
         with open(cache_path, "rb") as f:
-            return f.read(), "audio/mpeg"
+            audio = f.read()
+        logger.info("multi_tts cache hit provider=%s voice=%s bytes=%d", provider, voice, len(audio))
+        return audio, "audio/mpeg"
 
     voice_name = VOICES.get(voice, voice)
+    t_start = time.time()
+    logger.info("multi_tts start provider=%s voice=%s(%s) speed=%s phoneme=%s text_len=%d",
+                provider, voice, voice_name, speed, bool(phoneme_map), len(text))
 
     if provider == "azure":
         try:
             audio, media_type = await _azure_tts(text, voice_name, speed, phoneme_map)
         except Exception as e:
-            logger.warning("Azure TTS 失败，降级 edge-tts: %s", e)
+            logger.warning("Azure TTS 失败，降级 edge-tts: %s: %s", type(e).__name__, e, exc_info=True)
             audio, media_type = await _edge_tts(text, voice_name, speed)
     elif provider == "google":
         try:
             audio, media_type = await _google_tts(text, voice_name, speed)
         except Exception as e:
-            logger.warning("Google TTS 失败，降级 edge-tts: %s", e)
+            logger.warning("Google TTS 失败，降级 edge-tts: %s: %s", type(e).__name__, e, exc_info=True)
             audio, media_type = await _edge_tts(text, voice_name, speed)
     elif provider == "edge":
         audio, media_type = await _edge_tts(text, voice_name, speed)
@@ -221,6 +227,9 @@ async def multi_tts(text: str, provider: str = None, voice: str = "jenny",
         audio, media_type = await _openai_tts(text, voice)
     else:
         raise ValueError(f"Unknown provider: {provider}")
+
+    elapsed_ms = int((time.time() - t_start) * 1000)
+    logger.info("multi_tts done provider=%s bytes=%d ms=%d", provider, len(audio), elapsed_ms)
 
     with open(cache_path, "wb") as f:
         f.write(audio)


### PR DESCRIPTION
## 背景

线上反馈：连续点 🔊 发音 3 次后失败，后端 log 仅一行 \`speakeasy | socket.send() raised exception.\`，**信息量不足以定位**。

## 改动

只动 log，不动业务逻辑。

\`POST /practice/tts\` 每次调用打印：
- **入口**：rid（8 位随机 ID）+ provider/voice/speed/text_len/text 前 40 字预览
- **出口 OK**：rid + 实际字节数 + 总 ms
- **失败**：rid + 状态码 + 异常类型 + 消息 + 完整 traceback（\`exc_info=True\`）

\`multi_tts\` 层补：
- 起始 / cache 命中 / 完成 / 降级 fallback（异常类型 + traceback）

## 收益

下次出现 socket.send 时，通过 rid 串起一次完整链路，能立刻看到：
- fallback 是否触发
- 哪一层 stack 抛的（_azure_tts? _edge_tts? Response 写入?）
- 是否同一 client 短时间内连击

## Test

- [x] 36 passed (azure 20 + google 16)
- [x] 不改业务，单测全过

🤖 Generated with [Claude Code](https://claude.com/claude-code)