### PR TITLE
feat(practice): 手机端 FSRS 评分 · 录完自动进入打分模式 (#26 方案 C)

### DIFF
--- a/frontend/src/components/practice/MobileActionDock.vue
+++ b/frontend/src/components/practice/MobileActionDock.vue
@@ -119,10 +119,13 @@ const playbackDisabled = computed(() => !props.hasRecording)
     </template>
 
     <!-- #26 评分模式：录完自动切到这套（方案 C） -->
+    <!-- codex review: ratingBusy 时 redo/playback 也要 disable —— 否则评分请求在飞时点重录
+         会调 recorder.reset() 把新录音杀掉，等评分请求返回后还会跳句到错位置 -->
     <template v-else>
       <div class="dock-row">
         <button
           class="dock-btn"
+          :disabled="ratingBusy"
           aria-label="回放刚才的录音"
           @click="emit('playback')"
         >
@@ -132,6 +135,7 @@ const playbackDisabled = computed(() => !props.hasRecording)
         </button>
         <button
           class="dock-btn"
+          :disabled="ratingBusy"
           aria-label="退出打分，重新录一遍"
           @click="emit('redo-record')"
         >

--- a/frontend/src/components/practice/MobileActionDock.vue
+++ b/frontend/src/components/practice/MobileActionDock.vue
@@ -19,9 +19,15 @@ const props = defineProps({
   currentIdx:     { type: Number, default: 0 },
   totalSegments:  { type: Number, default: 0 },
   practicedCount: { type: Number, default: 0 },
+  ratingMode:     { type: Boolean, default: false },   // #26 录完自动进入
+  ratingBusy:     { type: Boolean, default: false },
 })
 
-const emit = defineEmits(['explain', 'speak', 'toggle-record', 'playback'])
+const emit = defineEmits([
+  'explain', 'speak', 'toggle-record', 'playback',
+  'rate',         // 评分 (#26)
+  'redo-record',  // 重录（退出 ratingMode 后立刻开新录音）
+])
 
 // 把 props 转 refs 喂 useCoachBar
 const state = {
@@ -64,51 +70,103 @@ const playbackDisabled = computed(() => !props.hasRecording)
       <span class="copy">{{ coachCopy }}</span>
     </div>
 
-    <div class="dock-row">
-      <button
-        class="dock-btn primary"
-        :aria-label="explainAria"
-        @click="emit('explain')"
-      >
-        <span class="ico" aria-hidden="true">💡</span>
-        <span class="label">{{ explainLabel }}</span>
-        <span v-if="subWord" class="sub">{{ subWord }}</span>
-      </button>
-      <button
-        class="dock-btn primary"
-        :aria-label="speakAria"
-        @click="emit('speak')"
-      >
-        <span class="ico" aria-hidden="true">🔊</span>
-        <span class="label">{{ speakLabel }}</span>
-        <span v-if="subWord" class="sub">{{ subWord }}</span>
-      </button>
-    </div>
-    <div class="dock-row">
-      <button
-        class="dock-btn record"
-        :class="{ recording }"
-        :aria-pressed="recording"
-        :aria-label="recording ? '停止录音' : '开始录音'"
-        @click="emit('toggle-record')"
-      >
-        <span class="ico" aria-hidden="true">{{ recording ? '⏹' : '🎤' }}</span>
-        <span class="label">{{ recording ? '停止' : '录音' }}</span>
-        <span class="sub">
-          {{ recording ? '录音中…' : (hasRecording ? '重录' : '开始录') }}
-        </span>
-      </button>
-      <button
-        class="dock-btn"
-        :aria-disabled="playbackDisabled"
-        :aria-label="playbackDisabled ? '回放，先录一段' : '回放录音'"
-        @click="emit('playback')"
-      >
-        <span class="ico" aria-hidden="true">▶</span>
-        <span class="label">回放</span>
-        <span class="sub">{{ playbackDisabled ? '无录音' : '听自己' }}</span>
-      </button>
-    </div>
+    <template v-if="!ratingMode">
+      <div class="dock-row">
+        <button
+          class="dock-btn primary"
+          :aria-label="explainAria"
+          @click="emit('explain')"
+        >
+          <span class="ico" aria-hidden="true">💡</span>
+          <span class="label">{{ explainLabel }}</span>
+          <span v-if="subWord" class="sub">{{ subWord }}</span>
+        </button>
+        <button
+          class="dock-btn primary"
+          :aria-label="speakAria"
+          @click="emit('speak')"
+        >
+          <span class="ico" aria-hidden="true">🔊</span>
+          <span class="label">{{ speakLabel }}</span>
+          <span v-if="subWord" class="sub">{{ subWord }}</span>
+        </button>
+      </div>
+      <div class="dock-row">
+        <button
+          class="dock-btn record"
+          :class="{ recording }"
+          :aria-pressed="recording"
+          :aria-label="recording ? '停止录音' : '开始录音'"
+          @click="emit('toggle-record')"
+        >
+          <span class="ico" aria-hidden="true">{{ recording ? '⏹' : '🎤' }}</span>
+          <span class="label">{{ recording ? '停止' : '录音' }}</span>
+          <span class="sub">
+            {{ recording ? '录音中…' : (hasRecording ? '重录' : '开始录') }}
+          </span>
+        </button>
+        <button
+          class="dock-btn"
+          :aria-disabled="playbackDisabled"
+          :aria-label="playbackDisabled ? '回放，先录一段' : '回放录音'"
+          @click="emit('playback')"
+        >
+          <span class="ico" aria-hidden="true">▶</span>
+          <span class="label">回放</span>
+          <span class="sub">{{ playbackDisabled ? '无录音' : '听自己' }}</span>
+        </button>
+      </div>
+    </template>
+
+    <!-- #26 评分模式：录完自动切到这套（方案 C） -->
+    <template v-else>
+      <div class="dock-row">
+        <button
+          class="dock-btn"
+          aria-label="回放刚才的录音"
+          @click="emit('playback')"
+        >
+          <span class="ico" aria-hidden="true">▶</span>
+          <span class="label">回放</span>
+          <span class="sub">听自己</span>
+        </button>
+        <button
+          class="dock-btn"
+          aria-label="退出打分，重新录一遍"
+          @click="emit('redo-record')"
+        >
+          <span class="ico" aria-hidden="true">🎤</span>
+          <span class="label">重录</span>
+          <span class="sub">重新来过</span>
+        </button>
+      </div>
+      <div class="dock-row rating-row">
+        <button
+          class="dock-btn rate rate-again"
+          :disabled="ratingBusy"
+          aria-label="Again · 完全不会"
+          @click="emit('rate', 'again')"
+        >Again</button>
+        <button
+          class="dock-btn rate rate-hard"
+          :disabled="ratingBusy"
+          aria-label="Hard · 卡壳"
+          @click="emit('rate', 'hard')"
+        >Hard</button>
+        <button
+          class="dock-btn rate rate-good"
+          :disabled="ratingBusy"
+          aria-label="Good · 顺"
+          @click="emit('rate', 'good')"
+        >Good</button>
+        <button
+          class="dock-btn rate rate-easy"
+          :disabled="ratingBusy"
+          aria-label="Easy · 太轻松"
+          @click="emit('rate', 'easy')"
+        >Easy</button>
+      </div>
+    </template>
   </div>
 </template>
 
@@ -179,6 +237,28 @@ const playbackDisabled = computed(() => !props.hasRecording)
   0%,100% { box-shadow: 0 0 0 0 rgba(198,70,58,0.4); }
   50%    { box-shadow: 0 0 0 8px rgba(198,70,58,0); }
 }
+
+/* #26 评分四色按钮 — 与桌面 PracticePlayer 对齐 */
+.rating-row .dock-btn.rate {
+  min-height: 48px;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  color: #fff;
+  border: none;
+}
+.rating-row .dock-btn.rate:disabled {
+  opacity: 0.55;
+  cursor: wait;
+}
+.rate-again { background: #c6463a; }
+.rate-hard  { background: #e08438; }
+.rate-good  { background: #2d8a4a; }
+.rate-easy  { background: #2c6cd9; }
+.rate-again:active { background: #a83b30; }
+.rate-hard:active  { background: #c66f2c; }
+.rate-good:active  { background: #24723c; }
+.rate-easy:active  { background: #2459b4; }
 
 @media (orientation: landscape) and (max-height: 500px) {
   .dock { padding-bottom: var(--space-2); }

--- a/frontend/src/components/practice/__tests__/MobileActionDock.spec.js
+++ b/frontend/src/components/practice/__tests__/MobileActionDock.spec.js
@@ -84,4 +84,16 @@ describe('MobileActionDock · 评分模式 (#26)', () => {
       expect(btn.attributes('disabled')).toBeDefined()
     }
   })
+
+  it('ratingBusy=true → 回放/重录也 disabled (codex review)', () => {
+    // 防止评分请求在飞期间用户点重录把新录音 reset 掉 / 跳句错位
+    const w = mountDock({ ratingMode: true, ratingBusy: true, hasRecording: true })
+    const labels = w.findAll('.dock-btn')
+    const redo = labels.find((b) => (b.attributes('aria-label') || '').includes('重新录'))
+    const playback = labels.find((b) => (b.attributes('aria-label') || '').includes('回放'))
+    expect(redo).toBeTruthy()
+    expect(playback).toBeTruthy()
+    expect(redo.attributes('disabled')).toBeDefined()
+    expect(playback.attributes('disabled')).toBeDefined()
+  })
 })

--- a/frontend/src/components/practice/__tests__/MobileActionDock.spec.js
+++ b/frontend/src/components/practice/__tests__/MobileActionDock.spec.js
@@ -1,0 +1,87 @@
+/**
+ * MobileActionDock · 评分模式 (#26)
+ *
+ * 覆盖：
+ *  - ratingMode=false 时显示默认 record/playback 行，不渲染评分按钮
+ *  - ratingMode=true 时显示评分 4 按钮 + 回放/重录
+ *  - 点 4 个评分按钮各 emit('rate', 对应 level)
+ *  - 点重录 emit('redo-record')
+ *  - ratingBusy=true 时评分按钮全 disabled
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+vi.mock('@/composables/useCoachBar', () => ({
+  useCoachBar: () => ({
+    coachCopy: { value: 'practice' },
+    coachClass: { value: '' },
+    coachProgress: { value: '1 / 10' },
+  }),
+}))
+
+import MobileActionDock from '../MobileActionDock.vue'
+
+function mountDock(props = {}) {
+  return mount(MobileActionDock, {
+    props: {
+      currentIdx: 0,
+      totalSegments: 10,
+      practicedCount: 0,
+      ...props,
+    },
+  })
+}
+
+describe('MobileActionDock · 评分模式 (#26)', () => {
+  it('默认模式：渲染录音/回放，不渲染评分按钮', () => {
+    const w = mountDock({ ratingMode: false })
+    expect(w.find('.dock-btn.record').exists()).toBe(true)
+    expect(w.findAll('.rate').length).toBe(0)
+  })
+
+  it('评分模式：渲染 4 个评分按钮 + 回放 + 重录，隐藏 explain/speak 行', () => {
+    const w = mountDock({ ratingMode: true, hasRecording: true })
+    const rateBtns = w.findAll('.rate')
+    expect(rateBtns.length).toBe(4)
+    expect(rateBtns[0].text()).toBe('Again')
+    expect(rateBtns[1].text()).toBe('Hard')
+    expect(rateBtns[2].text()).toBe('Good')
+    expect(rateBtns[3].text()).toBe('Easy')
+    // 默认模式的录音/语音按钮不在
+    expect(w.find('.dock-btn.record').exists()).toBe(false)
+    // 评分模式 dock 里有重录按钮（aria-label 含「重新录」）
+    const labels = w.findAll('.dock-btn').map((b) => b.attributes('aria-label') || '')
+    expect(labels.some((l) => l.includes('重新录'))).toBe(true)
+    expect(labels.some((l) => l.includes('回放'))).toBe(true)
+  })
+
+  it.each([
+    ['again', 0],
+    ['hard',  1],
+    ['good',  2],
+    ['easy',  3],
+  ])('点 %s → emit rate with %s', async (level, idx) => {
+    const w = mountDock({ ratingMode: true, hasRecording: true })
+    await w.findAll('.rate')[idx].trigger('click')
+    expect(w.emitted('rate')).toBeTruthy()
+    expect(w.emitted('rate')[0]).toEqual([level])
+  })
+
+  it('点重录按钮 → emit redo-record', async () => {
+    const w = mountDock({ ratingMode: true, hasRecording: true })
+    const redoBtn = w.findAll('.dock-btn').find((b) =>
+      (b.attributes('aria-label') || '').includes('重新录')
+    )
+    expect(redoBtn).toBeTruthy()
+    await redoBtn.trigger('click')
+    expect(w.emitted('redo-record')).toBeTruthy()
+  })
+
+  it('ratingBusy=true → 4 个评分按钮均 disabled', () => {
+    const w = mountDock({ ratingMode: true, ratingBusy: true, hasRecording: true })
+    const rateBtns = w.findAll('.rate')
+    for (const btn of rateBtns) {
+      expect(btn.attributes('disabled')).toBeDefined()
+    }
+  })
+})

--- a/frontend/src/views/Practice.vue
+++ b/frontend/src/views/Practice.vue
@@ -29,7 +29,7 @@ defineOptions({ name: 'Practice' })
 
 const router = useRouter()
 const store = usePracticeStore()
-const { createCards, ttsBlob } = usePractice()
+const { createCards, ttsBlob, rateCard } = usePractice()
 const { authFetch } = useAuthFetch()
 const recorder = useRecorder()
 const { isMobile } = useBreakpoint()
@@ -59,13 +59,14 @@ const recordingSegIdx = ref(null)
 const hasPlayedBack = ref(false)
 const isPlayingTTS = ref(false)
 const practicedCount = ref(0)
+// #26 手机端评分（方案 C：录完自动进入）
+const ratingMode = ref(false)
+const ratingBusy = ref(false)
 let _ttsAudio = null
 let _ttsUrl = null
 let _lastRequestKey = null
 
 useScrollLock(sheetOpen)
-
-const FSRS_NOTICE_KEY = 'v2:practice.fsrs_notice_seen'
 
 // 跨断点（resize 跨 768px）时清状态防泄漏
 watch(isMobile, () => {
@@ -74,23 +75,25 @@ watch(isMobile, () => {
   _releaseTTS()
   if (recorder.recording.value) recorder.stop()
   recordingSegIdx.value = null
+  ratingMode.value = false
 })
 
-// 首次进入弹一次 FSRS toast（仅手机端弹）
+// 录音停下且已有录音 → 自动进入评分模式（#26 方案 C）
 watch(
-  [isMobile, hasSource],
-  ([m, has]) => {
-    if (!m || !has) return
-    try {
-      if (!localStorage.getItem(FSRS_NOTICE_KEY)) {
-        setTimeout(() => {
-          showToast('ℹ︎ 手机端暂不记录复习评分，仍可正常练习', 'info', 4000)
-          localStorage.setItem(FSRS_NOTICE_KEY, '1')
-        }, 400)
-      }
-    } catch { /* ignore */ }
-  },
-  { immediate: true }
+  () => recorder.recording.value,
+  (isRec, wasRec) => {
+    if (wasRec && !isRec && recorder.url.value && isMobile.value) {
+      ratingMode.value = true
+    }
+  }
+)
+
+// 切句即退出评分模式（避免拿上一句的评分意图给新句）
+watch(
+  () => store.currentIdx,
+  () => {
+    ratingMode.value = false
+  }
 )
 
 function gotoBbcReview() {
@@ -286,6 +289,7 @@ async function onMobileToggleRecord() {
     hasPlayedBack.value = false
   } else {
     recorder.reset()
+    ratingMode.value = false       // 新一轮，退出评分（如有）
     await recorder.start()
     if (recorder.error.value) {
       showToast(recorder.error.value, 'error')
@@ -303,6 +307,47 @@ function onMobilePlayback() {
   const a = new Audio(recorder.url.value)
   a.play()
   hasPlayedBack.value = true
+}
+
+// #26 评分模式（方案 C）— 录完自动进入；选完评分自动跳下一句
+async function onMobileRate(level) {
+  if (ratingBusy.value) return
+  const card = store.cards.find((c) => c.segIdx === store.currentIdx)
+  if (!card?.id) {
+    showToast('卡片未就绪，重新选一下句子再来', 'error', 2000)
+    ratingMode.value = false
+    return
+  }
+  ratingBusy.value = true
+  try {
+    await rateCard(card.id, level)
+    store.markPracticed(store.currentIdx, level)
+    showToast(`✅ 已评 ${({ again: 'Again', hard: 'Hard', good: 'Good', easy: 'Easy' })[level]}`, 'success', 1200)
+    ratingMode.value = false
+    recorder.reset()
+    hasPlayedBack.value = false
+    if (store.currentIdx < store.segments.length - 1) {
+      setTimeout(() => store.setCurrentIdx(store.currentIdx + 1), 400)
+    }
+  } catch (err) {
+    const msg = getErrorMessage(err, '评分失败')
+    if (msg) showToast(msg, 'error')
+  } finally {
+    ratingBusy.value = false
+  }
+}
+
+async function onMobileRedoRecord() {
+  // 退出评分 + 立即开新录音
+  ratingMode.value = false
+  recorder.reset()
+  hasPlayedBack.value = false
+  await recorder.start()
+  if (recorder.error.value) {
+    showToast(recorder.error.value, 'error')
+    return
+  }
+  recordingSegIdx.value = store.currentIdx
 }
 
 // ⚙ sheet 焦点管理（spec §可访问性 #5）
@@ -430,10 +475,14 @@ onBeforeUnmount(() => {
         :current-idx="store.currentIdx"
         :total-segments="store.segments.length"
         :practiced-count="practicedCount"
+        :rating-mode="ratingMode"
+        :rating-busy="ratingBusy"
         @explain="onMobileExplain"
         @speak="onMobileSpeak"
         @toggle-record="onMobileToggleRecord"
         @playback="onMobilePlayback"
+        @rate="onMobileRate"
+        @redo-record="onMobileRedoRecord"
       />
     </template>
 

--- a/frontend/src/views/Practice.vue
+++ b/frontend/src/views/Practice.vue
@@ -579,9 +579,8 @@ onBeforeUnmount(() => {
             </button>
 
             <div class="sheet-footer-note">
-              ℹ︎ 关于复习评分 · 手机端暂不评分，本次练习不会进入 FSRS 复习计划；
-              如需评分请到桌面端，或关注
-              <a href="https://github.com/bob798/speakeasy/issues/26" target="_blank" rel="noopener">issue #26</a>。
+              ℹ︎ 关于复习评分 · 录完一句后会自动出现 Again / Hard / Good / Easy 评分，
+              FSRS 会按你的反馈安排下次复习。点「重录」可重新来过。
             </div>
           </aside>
         </div>

--- a/frontend/src/views/Practice.vue
+++ b/frontend/src/views/Practice.vue
@@ -287,8 +287,10 @@ async function onMobileSpeak() {
 
 async function onMobileToggleRecord() {
   if (recorder.recording.value) {
+    // codex round 2: 不再立刻清 recordingSegIdx —— 它是「这段录音属于哪一句」的标记，
+    // onstop 异步落地后 watcher 才能用它判断是否给当前句开评分模式。
+    // 留到下次 start() 时再覆盖。
     recorder.stop()
-    recordingSegIdx.value = null
     hasPlayedBack.value = false
   } else {
     recorder.reset()

--- a/frontend/src/views/Practice.vue
+++ b/frontend/src/views/Practice.vue
@@ -79,10 +79,14 @@ watch(isMobile, () => {
 })
 
 // 录音停下且已有录音 → 自动进入评分模式（#26 方案 C）
+// codex review: 仅当录音归属当前句时才进；否则切句中途 onstop 异步落地会给新句错误开启评分
 watch(
   () => recorder.recording.value,
   (isRec, wasRec) => {
-    if (wasRec && !isRec && recorder.url.value && isMobile.value) {
+    if (
+      wasRec && !isRec && recorder.url.value && isMobile.value &&
+      recordingSegIdx.value === store.currentIdx
+    ) {
       ratingMode.value = true
     }
   }
@@ -226,8 +230,7 @@ function onMobileSelectSentence(idx) {
     recordingSegIdx.value = null
   }
   _releaseTTS()
-  // 离开旧句视作"完成一句"（v1 用切句作信号；issue #26 评分恢复后改为按 Good/Easy 计）
-  if (store.currentIdx !== idx) practicedCount.value += 1
+  // codex review (#26): practicedCount 不再随切句自增；只有评分成功才计，否则 coach 文案与实际进度不符
   store.setCurrentIdx(idx)
   selectedWord.value = null
   hasPlayedBack.value = false
@@ -310,9 +313,13 @@ function onMobilePlayback() {
 }
 
 // #26 评分模式（方案 C）— 录完自动进入；选完评分自动跳下一句
+// codex review:
+//  - 把 ratedIdx 在 await 前捕获，避免用户切句中途让 markPracticed/跳句落到错段
+//  - 评分成功后 practicedCount 自增（之前只在切句时 +1，导致 coach 文案与实际不符）
 async function onMobileRate(level) {
   if (ratingBusy.value) return
-  const card = store.cards.find((c) => c.segIdx === store.currentIdx)
+  const ratedIdx = store.currentIdx
+  const card = store.cards.find((c) => c.segIdx === ratedIdx)
   if (!card?.id) {
     showToast('卡片未就绪，重新选一下句子再来', 'error', 2000)
     ratingMode.value = false
@@ -321,13 +328,23 @@ async function onMobileRate(level) {
   ratingBusy.value = true
   try {
     await rateCard(card.id, level)
-    store.markPracticed(store.currentIdx, level)
+    // 评分写到的是 ratedIdx 的卡，markPracticed 也必须对齐 ratedIdx
+    store.markPracticed(ratedIdx, level)
+    practicedCount.value += 1
     showToast(`✅ 已评 ${({ again: 'Again', hard: 'Hard', good: 'Good', easy: 'Easy' })[level]}`, 'success', 1200)
-    ratingMode.value = false
-    recorder.reset()
-    hasPlayedBack.value = false
-    if (store.currentIdx < store.segments.length - 1) {
-      setTimeout(() => store.setCurrentIdx(store.currentIdx + 1), 400)
+    // 用户在请求过程中可能已切句 / 重录，只有当前还停在被评分的那一句才推动 UI
+    if (store.currentIdx === ratedIdx) {
+      ratingMode.value = false
+      recorder.reset()
+      hasPlayedBack.value = false
+      if (ratedIdx < store.segments.length - 1) {
+        setTimeout(() => {
+          // 二次校验：定时器触发时用户仍在 ratedIdx 才跳
+          if (store.currentIdx === ratedIdx) {
+            store.setCurrentIdx(ratedIdx + 1)
+          }
+        }, 400)
+      }
     }
   } catch (err) {
     const msg = getErrorMessage(err, '评分失败')


### PR DESCRIPTION
## Summary

之前 V0.12 手机端 Practice 重设计为了 dock 不拥挤暂时去掉了评分入口，结果**手机端 FSRS 调度链路是断的**（卡片永远到期，永远不会按记忆曲线复习）。本次按 #26 提出的**方案 C：录完音 → 自动进入打分模式**接回。

## UX 流程

```
默认 dock                录完停下                选完评分
─────────                ─────────              ─────────
[💡解释][🔊发音]    →   [▶回放][🎤重录]    →    跳下一句
[🎤录音][▶回放]         [Again Hard Good Easy]   退出 ratingMode
```

- **进入条件**：`recorder.recording` 由 true → false 且 `recorder.url` 存在
- **重录**：立即退出 ratingMode + 开新录音（避免「评分模式锁死」）
- **切句 / 重新开录 / 跨断点**：强制退出 ratingMode，防止把上一句评分意图带到新句

## 改动

**前端**
- `MobileActionDock.vue`: 加 `ratingMode` + `ratingBusy` props，加 `rate` + `redo-record` emits；评分 4 色按钮与桌面 PracticePlayer 对齐
- `Practice.vue`: 加 `ratingMode` / `ratingBusy` refs；watch recorder 状态自动进入；接 `usePractice().rateCard` 复用桌面 FSRS 链路；删掉「手机端暂不记录复习评分」toast 和 `FSRS_NOTICE_KEY`
- **零后端改动** —— 走的还是 `POST /practice/cards/{id}/review`

**测试**（`frontend/src/components/practice/__tests__/MobileActionDock.spec.js` 新文件）
- 默认模式渲染录音/回放，不渲染评分按钮
- 评分模式渲染 4 评分按钮 + 回放 + 重录
- 4 个评分按钮各 emit `rate(level)`
- 重录 emit `redo-record`
- `ratingBusy=true` → 评分按钮全 disabled

## Test plan

- [x] `npm test` → 33 passed（旧 25 + 新 8 MobileActionDock）
- [x] `npm run build` 通过
- [ ] 手机真机 dev 验收（验收 by Human）：录完音 → dock 切到 4 色 → 点 Good → 0.4s 后跳下一句 + dock 回到默认
- [ ] 录完后点重录 → 立刻退出 ratingMode + 开始录音
- [ ] 录完后切句 → 退出 ratingMode 不带入新句
- [ ] 桌面端（>=768px）完全不受影响

## 关联

- Close #26
- 评分链路接的是 V0.4 的 `pronunciation_cards` 表 + `usePractice().rateCard`，与桌面端一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)