### PR TITLE
fix(main): /vocabulary 误被 API_PREFIXES 拦截 404

### DIFF
--- a/main.py
+++ b/main.py
@@ -47,7 +47,6 @@ API_PREFIXES = (
     "practice/",
     "articles/",
     "translate/",
-    "vocab",
     "vocab/",
     "polish/",
     "auth/",

--- a/tests/test_v08_vocabulary_spa_fallback.py
+++ b/tests/test_v08_vocabulary_spa_fallback.py
@@ -1,0 +1,42 @@
+"""V0.8 hotfix: /vocabulary 应走 SPA fallback，不被 API_PREFIXES 误拦截为 404。
+
+Regression：早先 API_PREFIXES 含 "vocab" 前缀（无斜杠），
+`"vocabulary".startswith("vocab")` 命中 → catch-all 抛 404，
+导致前端 /vocabulary 独立页无法直达访问。
+"""
+import pytest
+from fastapi.testclient import TestClient
+
+from main import app
+
+
+client = TestClient(app)
+
+
+def test_vocabulary_returns_200_via_spa_fallback():
+    """GET /vocabulary 必须被 SPA fallback 接管（不能 404）。"""
+    resp = client.get("/vocabulary")
+    assert resp.status_code == 200, (
+        f"/vocabulary 应走 SPA fallback，实际 {resp.status_code}：{resp.text[:200]}"
+    )
+
+
+def test_vocab_get_still_routed_to_api():
+    """对照：/vocab 仍由 FastAPI 路由系统命中（不会变成 SPA fallback）。"""
+    resp = client.get("/vocab")
+    # 没带 auth → 401 表示路由到了 /vocab 但被鉴权拦截；非 404 / 非 200 SPA HTML。
+    # 关键是 content-type 不是 HTML（说明走的不是 SPA fallback）。
+    ctype = resp.headers.get("content-type", "")
+    assert "json" in ctype or resp.status_code in (401, 422, 403), (
+        f"/vocab 应走 API 路由，content-type={ctype}, status={resp.status_code}"
+    )
+
+
+def test_vocab_with_subpath_still_blocked_by_api_prefix():
+    """/vocab/{id} 类未命中路径仍应被 API_PREFIXES 拦截（"vocab/" 前缀保留）。"""
+    resp = client.get("/vocab/non-existent-path-12345")
+    # 不应返回 SPA HTML；应是 404 (route not found) or 401 (auth)。
+    ctype = resp.headers.get("content-type", "")
+    assert "html" not in ctype, (
+        f"/vocab/xxx 不应走 SPA fallback，content-type={ctype}"
+    )


### PR DESCRIPTION
## Summary

V0.8 上线后生产验收发现 `GET /vocabulary` 返回 404。根因：`main.py:38` 的 `API_PREFIXES` 同时含 `"vocab"` 和 `"vocab/"`，catch-all 用 `startswith` 判断 → `"vocabulary".startswith("vocab")` 命中 → 走 404 分支，让 V0.8 新加的独立生词本页直达访问失败。

## Fix

删除 `"vocab"` 单条，只保留 `"vocab/"`：
- POST/GET/DELETE `/vocab` → FastAPI 路由优先命中，与 API_PREFIXES 无关
- `/vocab/{id}` 类未命中路径 → 仍被 `"vocab/"` 兜底，不被 SPA fallback 接管
- `/vocabulary` → 不再误中前缀 → SPA fallback → 200 + index.html

## Test plan

- [x] `tests/test_v08_vocabulary_spa_fallback.py` 3 个回归测试全绿
- [x] V0.8 全量后端测试 37/37（含新增 3）
- [ ] 部署后 `curl https://speakeasy.bobloveanita.com/vocabulary` 返回 200 + HTML
- [ ] `curl https://speakeasy.bobloveanita.com/vocab` 仍 401/200（API 行为不变）

🤖 Generated with [Claude Code](https://claude.com/claude-code)