### PR TITLE
chore(v08): 清理 V0.8 后残留的 /practice 引用

### DIFF
--- a/frontend/src/components/ExplanationModal.vue
+++ b/frontend/src/components/ExplanationModal.vue
@@ -537,7 +537,7 @@ async function playIPA(key, text, ipa) {
   ipaState.value = 'loading'
 
   try {
-    const resp = await authFetch(`${API.PRACTICE}/tts`, {
+    const resp = await authFetch(`${API.ARTICLES}/tts`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/frontend/src/components/__tests__/ExplanationModal.spec.js
+++ b/frontend/src/components/__tests__/ExplanationModal.spec.js
@@ -154,7 +154,7 @@ describe('ExplanationModal · IPA 🎧 按钮', () => {
     expect(btns[1].attributes('aria-label')).toContain('would you')
   })
 
-  it('word: 点 🎧 发 POST /practice/tts，body 含正确 phoneme_map', async () => {
+  it('word: 点 🎧 发 POST /articles/tts，body 含正确 phoneme_map', async () => {
     authFetchMock.mockResolvedValue({
       ok: true,
       blob: async () => new Blob([new Uint8Array([1, 2, 3])], { type: 'audio/mpeg' }),
@@ -168,7 +168,7 @@ describe('ExplanationModal · IPA 🎧 按钮', () => {
 
     expect(authFetchMock).toHaveBeenCalledOnce()
     const [url, opts] = authFetchMock.mock.calls[0]
-    expect(url).toBe('/practice/tts')
+    expect(url).toBe('/articles/tts')
     expect(opts.method).toBe('POST')
     const body = JSON.parse(opts.body)
     expect(body.text).toBe('schedule')

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -95,7 +95,7 @@ onMounted(() => {
       <div v-if="stats.today_message_count > 0" class="chip">
         💬 <span>今日 {{ stats.today_message_count }} 条</span>
       </div>
-      <RouterLink v-if="stats.due_cards > 0" to="/practice" class="chip cta">
+      <RouterLink v-if="stats.due_cards > 0" to="/articles" class="chip cta">
         📝 <span>{{ stats.due_cards }} 张待复习</span>
       </RouterLink>
     </div>
@@ -151,7 +151,7 @@ onMounted(() => {
       </RouterLink>
       <RouterLink to="/translate" class="sec-item">
         <span class="ico">🌐</span>
-        <span class="name">翻译 · 生词本</span>
+        <span class="name">翻译</span>
       </RouterLink>
       <RouterLink to="/vocabulary" class="sec-item">
         <span class="ico">📖</span>


### PR DESCRIPTION
## Summary

Final reviewer 提到的 3 个 minor follow-up（都因后端 \`/practice/*\` alias 兜底所以功能上没坏，但语义不一致）。

- \`Home.vue:98\` — \"📝 待复习\" chip 链接 \`/practice\` → \`/articles\`（少一跳 redirect）
- \`Home.vue:154\` — 二级导航标签 \"翻译 · 生词本\" → \"翻译\"
  （V0.8 已经把 vocabulary 面板从 /translate 迁到 /vocabulary，标签误导用户）
- \`ExplanationModal.vue:540\` — IPA TTS \`API.PRACTICE\` → \`API.ARTICLES\`
  + 同步更新 \`ExplanationModal.spec.js\` 断言 + 测试描述

## Test plan

- [x] \`npm run test\` → 70/70 全绿
- [ ] 部署后验证 IPA 🎧 按钮仍能正常发音（Azure SSML phoneme）
- [ ] Home.vue 二级导航卡片显示 \"翻译\" 而不是 \"翻译 · 生词本\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)