### PR TITLE
fix(frontend): 解读错误显示 "[object Object]" → 真实错误文案

### DIFF
--- a/frontend/src/composables/__tests__/useAuthFetch.spec.js
+++ b/frontend/src/composables/__tests__/useAuthFetch.spec.js
@@ -70,6 +70,34 @@ describe('useAuthFetch', () => {
     await expect(authFetchJson('/api/boom', { x: 1 })).rejects.toThrow('服务器内部错误')
   })
 
+  it('422 路径: FastAPI 校验数组 detail 转成可读文案（避免 [object Object]）', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          detail: [
+            { loc: ['body', 'text'], msg: 'field required', type: 'value_error.missing' },
+            { loc: ['body', 'kind'], msg: 'value is not a valid enumeration member', type: 'type_error.enum' },
+          ],
+        }),
+        { status: 422 }
+      )
+    )
+
+    const { authFetchJson } = useAuthFetch()
+    await expect(authFetchJson('/api/bad', {})).rejects.toThrow(
+      /field required.*value is not a valid enumeration member/
+    )
+  })
+
+  it('对象 detail: stringify 而非 [object Object]', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ detail: { code: 'X', reason: 'Y' } }), { status: 500 })
+    )
+
+    const { authFetchJson } = useAuthFetch()
+    await expect(authFetchJson('/api/weird', {})).rejects.toThrow(/"code":"X"/)
+  })
+
   it('network 错误路径: 透传 fetch 抛出的错误', async () => {
     fetchMock.mockRejectedValueOnce(new TypeError('Failed to fetch'))
 

--- a/frontend/src/composables/useAuthFetch.js
+++ b/frontend/src/composables/useAuthFetch.js
@@ -91,8 +91,17 @@ export function useAuthFetch() {
     if (!resp.ok) {
       let detail = `HTTP ${resp.status}`
       try {
-        const err = await resp.json()
-        detail = err.detail || err.error || detail
+        const body = await resp.json()
+        const raw = body?.detail ?? body?.error
+        if (typeof raw === 'string') {
+          detail = raw
+        } else if (Array.isArray(raw)) {
+          // FastAPI 422: [{loc, msg, type, ...}, ...] — 转成可读文案
+          const parts = raw.map((d) => (d && typeof d === 'object' && d.msg) || JSON.stringify(d))
+          if (parts.length) detail = parts.join('; ')
+        } else if (raw != null && typeof raw === 'object') {
+          detail = JSON.stringify(raw)
+        }
       } catch {
         /* ignore parse error */
       }


### PR DESCRIPTION
## Summary
- `authFetchJson` 把后端 `err.detail` 直接传给 `new Error()`，遇到 FastAPI 422 数组 / 对象型 detail 时 `Error.message` 被强转成 `"[object Object]"`，所有 catch 路径（ExplanationModal / useAskThread / PracticePlayer / SubtitleImport / ReviewHome / Vocabulary）都丢失了真实错误信息。
- 按 detail 类型分支处理：string 原样、array 取每项 `msg` 用 `; ` 拼接、object 走 `JSON.stringify`。
- 补 2 个 useAuthFetch 单测覆盖 422 数组与对象 detail。

## Background
线上点击 `throughout` 单词解读时弹出 `❌ [object Object]`（截图见 issue 触发会话）。修完之后真实错误才会现形，再追服务端具体问题。

## Test plan
- [x] `npx vitest run src/composables/__tests__/useAuthFetch.spec.js` —— 8/8
- [x] `npx vitest run` 全量 —— 72/72
- [ ] 合入后在前端复现 throughout 解读，确认错误文案不再是 `[object Object]`，并贴回真实文案以定位服务端问题

🤖 Generated with [Claude Code](https://claude.com/claude-code)