### PR TITLE
fix(frontend): source_ref 整数强转 string，修复 /articles/explain 422

### DIFF
--- a/frontend/src/components/ExplanationModal.vue
+++ b/frontend/src/components/ExplanationModal.vue
@@ -197,25 +197,29 @@ const inferredItemType = computed(() => {
   return 'sentence'
 })
 
+// 后端 source_ref: Optional[str]。SubtitleSource.id 是 Integer，
+// 不做强转会让 Pydantic 422 "Input should be a valid string"。
+const _refStr = (v) => (v == null || v === '' ? null : String(v))
+
 function deriveVocabSource() {
   // 来源由父组件透传到 target.context；下面的 fallback 兼容老调用
   const ctx = props.target?.context || {}
-  // 父组件优先：显式传入 vocab_source_type / vocab_source_ref
+  let source_type, raw
   if (ctx.vocab_source_type) {
-    return {
-      source_type: ctx.vocab_source_type,
-      source_ref: ctx.vocab_source_ref || null,
-    }
+    source_type = ctx.vocab_source_type
+    raw = ctx.vocab_source_ref
+  } else if (ctx.source === 'chat') {
+    source_type = 'chat'
+    raw = ctx.session_id
+  } else if (ctx.source === 'practice') {
+    source_type = 'practice'
+    raw = ctx.source_id
+  } else {
+    // 解读页 / 其它
+    source_type = 'translate'
+    raw = null
   }
-  // 老路径推断
-  if (ctx.source === 'chat') {
-    return { source_type: 'chat', source_ref: ctx.session_id || null }
-  }
-  if (ctx.source === 'practice') {
-    return { source_type: 'practice', source_ref: ctx.source_id || null }
-  }
-  // 解读页 / 其它
-  return { source_type: 'translate', source_ref: null }
+  return { source_type, source_ref: _refStr(raw) }
 }
 
 const data = ref({

--- a/frontend/src/components/__tests__/ExplanationModal.spec.js
+++ b/frontend/src/components/__tests__/ExplanationModal.spec.js
@@ -258,6 +258,26 @@ describe('ExplanationModal · IPA 🎧 按钮', () => {
     expect(capturedBody.item_type).toBe('sentence')
   })
 
+  it('word: source_ref 是整数（SubtitleSource.id）时强转 string，避免 Pydantic 422', async () => {
+    const wrapper = await mountModal({
+      target: {
+        type: 'word',
+        content: 'throughout',
+        sentence: 'go on throughout the day',
+        context: { vocab_source_type: 'practice', vocab_source_ref: 42 },
+      },
+      dataPatch: { phonetic: 'θruːˈaʊt' },
+    })
+    await flushPromises()
+
+    const [, phoneticBody] = authFetchJsonMock.mock.calls[0]
+    const [, explainBody] = authFetchJsonMock.mock.calls[1]
+    expect(phoneticBody.source_ref).toBe('42')
+    expect(typeof phoneticBody.source_ref).toBe('string')
+    expect(explainBody.source_ref).toBe('42')
+    expect(typeof explainBody.source_ref).toBe('string')
+  })
+
   it('word phrase: item_type is "phrase" for multi-token word', async () => {
     const wrapper = await mountModal({
       target: { type: 'word', content: 'give up' },

--- a/frontend/src/views/Articles.vue
+++ b/frontend/src/views/Articles.vue
@@ -190,9 +190,12 @@ function onExplain(payload) {
   }
   const src = store.currentSource || {}
   const isBbc = src.source_type === 'bbc_eaw' || src.type === 'bbc_eaw'
+  // SubtitleSource.id 是 Integer，必须强转 string 后再塞入；
+  // 后端 source_ref: Optional[str]，数字会被 Pydantic 拒收。
+  const refStr = (v) => (v == null || v === '' ? null : String(v))
   const vocabRef = isBbc
-    ? { vocab_source_type: 'bbc_eaw', vocab_source_ref: src.slug || src.id || null }
-    : { vocab_source_type: 'practice', vocab_source_ref: src.id || src.source_id || null }
+    ? { vocab_source_type: 'bbc_eaw', vocab_source_ref: refStr(src.slug) || refStr(src.id) }
+    : { vocab_source_type: 'practice', vocab_source_ref: refStr(src.id) || refStr(src.source_id) }
   target.context = {
     source: 'practice',
     source_id: src.id,


### PR DESCRIPTION
## Summary
- 后端 \`ExplainRequest.source_ref: Optional[str]\`，但 \`SubtitleSource.id\` 是 \`Integer\` 主键。\`Articles.vue:onExplain\` 直接把 \`src.id\` 塞进 \`vocab_source_ref\`，导致 \`/articles/explain\` 收到 \`source_ref: 42\`（数字），Pydantic 拒收，前端报 \`❌ Input should be a valid string\`。
- 修复两处：
  - **数据源头** — \`Articles.vue:onExplain\` 用 \`refStr()\` 把 \`src.id\` / \`src.source_id\` / \`src.slug\` 统一强转 string
  - **出口兜底** — \`ExplanationModal.vue:deriveVocabSource()\` 用 \`_refStr()\` 兜底强转，覆盖未来任何外部传入数字的回归
- 补 ExplanationModal 单测：\`vocab_source_ref: 42\` → 两个请求体 \`source_ref === '42'\` 且 \`typeof === 'string'\`

## Background
PR #50 修了前端展示层，让真实错误现形。点 \`throughout\` 解读时报 \`Input should be a valid string\` 就是这条链路的隐藏 bug。

## Test plan
- [x] \`npx vitest run\` —— 73/73（含 1 个新增 source_ref 强转测）
- [ ] 合入后复现：在 Articles 页点单词 → ExplanationModal 解读成功（不再 422）

🤖 Generated with [Claude Code](https://claude.com/claude-code)