### PR TITLE
feat(translate): 翻译自动入生词本 — 占位 + 回填

### DIFF
--- a/app/routers/translate.py
+++ b/app/routers/translate.py
@@ -5,9 +5,9 @@ from typing import Optional
 from fastapi import APIRouter, HTTPException, Query, Depends
 from pydantic import BaseModel
 
-from app.services.translate_service import translate_text
-from app.services.vocab_service import save_item, list_items, delete_item
-from app.routers.auth import get_current_user_id
+from app.services.translate_service import translate_text, VALID_DIRECTIONS
+from app.services.vocab_service import save_item, list_items, delete_item, update_translated_text
+from app.routers.auth import get_current_user_id, get_current_user_id_optional
 from app.logger import get_logger
 
 logger = get_logger("translate")
@@ -40,14 +40,39 @@ class VocabularyResponse(BaseModel):
     created_at: Optional[str]
 
 
-# ── 翻译（匿名可用）──────────────────────────────────────
+# ── 翻译（匿名可用，登录自动入生词本）──────────────────
 
 @router.post("/translate/text")
-async def do_translate(req: TranslateRequest):
+async def do_translate(
+    req: TranslateRequest,
+    user_id: Optional[str] = Depends(get_current_user_id_optional),
+):
     if len(req.text.strip()) == 0:
         raise HTTPException(400, "输入文本不能为空")
     if len(req.text.strip()) > 1000:
         raise HTTPException(400, "输入文本不能超过 1000 字符")
+
+    # direction 白名单校验（提前到占位写入之前）
+    if req.direction not in VALID_DIRECTIONS:
+        raise HTTPException(400, f"无效的翻译方向: {req.direction}，可选值: zh2en / en2zh")
+
+    # 登录态：占位写入 vocabulary
+    vocab_id = None
+    if user_id:
+        try:
+            item = save_item(
+                user_id=user_id,
+                source_text=req.text,
+                translated_text="",
+                direction=req.direction,
+                item_type="sentence",
+                source_type="translate",
+                source_ref=None,
+            )
+            vocab_id = item["id"]
+        except Exception as e:
+            logger.warning("translate_placeholder_save_fail user=%s err=%s", user_id, e)
+            vocab_id = None
 
     try:
         translated = await translate_text(req.text, req.direction)
@@ -57,7 +82,27 @@ async def do_translate(req: TranslateRequest):
         logger.error("翻译失败: %s", e, exc_info=True)
         raise HTTPException(503, "翻译服务暂时不可用，请稍后重试")
 
-    return {"translated_text": translated}
+    # 登录态：回填 translated_text
+    if user_id and vocab_id and translated:
+        try:
+            update_translated_text(
+                user_id=user_id,
+                source_text=req.text,
+                source_ref=None,
+                translated_text=translated,
+                force=True,
+            )
+        except Exception as e:
+            logger.warning(
+                "translate_backfill_fail user=%s vocab_id=%s err=%s",
+                user_id, vocab_id, e,
+            )
+
+    return {
+        "translated_text": translated,
+        "saved_to_vocab": bool(vocab_id),
+        "vocab_id": vocab_id,
+    }
 
 
 # ── 生词本 CRUD（登录才能用）──────────────────────────────

--- a/app/services/model_client.py
+++ b/app/services/model_client.py
@@ -1,6 +1,6 @@
 import os
 import time
-from typing import AsyncGenerator
+from typing import AsyncGenerator, Optional
 import httpx
 import anthropic
 from openai import OpenAI
@@ -90,7 +90,7 @@ class BaseModelClient:
         messages_or_prompt,
         max_tokens: int = 1000,
         scene: str = "default",
-        timeout: float | None = None,
+        timeout: Optional[float] = None,
     ) -> str:
         """
         单次 LLM 调用，返回纯文本。
@@ -114,7 +114,7 @@ class BaseModelClient:
         messages: list,
         max_tokens: int,
         scene: str = "default",
-        timeout: float | None = None,
+        timeout: Optional[float] = None,
     ) -> str:
         raise NotImplementedError
 
@@ -212,7 +212,7 @@ class AnthropicClient(BaseModelClient):
         messages: list,
         max_tokens: int,
         scene: str = "default",
-        timeout: float | None = None,
+        timeout: Optional[float] = None,
     ) -> str:
         t0 = time.time()
         system = next((m["content"] for m in messages if m.get("role") == "system"), None)
@@ -336,7 +336,7 @@ class OpenAICompatibleClient(BaseModelClient):
         messages: list,
         max_tokens: int,
         scene: str = "default",
-        timeout: float | None = None,
+        timeout: Optional[float] = None,
     ) -> str:
         t0 = time.time()
         kwargs = {

--- a/app/services/vocab_service.py
+++ b/app/services/vocab_service.py
@@ -25,7 +25,7 @@ from app.logger import get_logger
 logger = get_logger("vocab_service")
 
 VALID_ITEM_TYPES = {"word", "phrase", "sentence"}
-VALID_SOURCE_TYPES = {"translate", "bbc_eaw", "practice", "chat"}
+VALID_SOURCE_TYPES = {"translate", "article", "practice", "chat"}
 
 
 def _to_dict(v: Vocabulary) -> Dict:
@@ -39,6 +39,7 @@ def _to_dict(v: Vocabulary) -> Dict:
         "item_type": v.item_type,
         "source_type": v.source_type,
         "source_ref": v.source_ref,
+        "series": v.series,
         "explanation_json": v.explanation_json,
         "status": v.status,
         "created_at": v.created_at.isoformat() if v.created_at else None,
@@ -58,6 +59,7 @@ def save_item(
     source_type: str = "translate",
     source_ref: Optional[str] = None,
     explanation_json: Optional[str] = None,
+    series: Optional[str] = None,
 ) -> Dict:
     """新增或返回已存在条目（去重键: user_id + source_text + source_ref）"""
     if not source_text or not source_text.strip():
@@ -91,6 +93,7 @@ def save_item(
             item_type=item_type,
             source_type=source_type,
             source_ref=source_ref,
+            series=series,
             explanation_json=explanation_json,
             fsrs_card_data=create_card(),
             status="active",
@@ -146,6 +149,41 @@ def update_explanation(
         logger.info(
             "vocab_explanation_backfill user_id=%s id=%s len=%d force=%s",
             user_id, v.id, len(explanation_json), force,
+        )
+        return True
+
+
+def update_translated_text(
+    user_id: str,
+    source_text: str,
+    source_ref: Optional[str],
+    translated_text: str,
+    force: bool = True,
+) -> bool:
+    """回填 translated_text。
+
+    默认覆盖(force=True),保持「页面看到啥 = 生词本里是啥」。
+    找不到记录返回 False,不抛异常。
+    """
+    with OrmSession(engine) as s:
+        v = (
+            s.query(Vocabulary)
+            .filter_by(user_id=user_id, source_text=source_text, source_ref=source_ref)
+            .first()
+        )
+        if not v:
+            logger.warning(
+                "vocab_translated_text_backfill_miss user_id=%s source_text=%s source_ref=%s",
+                user_id, source_text, source_ref,
+            )
+            return False
+        if v.translated_text and not force:
+            return False
+        v.translated_text = translated_text
+        s.commit()
+        logger.info(
+            "vocab_translated_text_backfill user_id=%s id=%s force=%s",
+            user_id, v.id, force,
         )
         return True
 
@@ -225,8 +263,9 @@ def bulk_save_from_bbc(
             direction="en2zh",
             context=seg.get("context"),
             item_type="sentence",
-            source_type="bbc_eaw",
+            source_type="article",
             source_ref=slug,
+            series="bbc_eaw",
         )
         # 粗略判定：刚创建的 last_reviewed_at 必为 None
         if item.get("last_reviewed_at") is None:

--- a/frontend/src/views/Translate.vue
+++ b/frontend/src/views/Translate.vue
@@ -8,9 +8,11 @@
  */
 import { ref, computed } from 'vue'
 import { useAuthFetch, getErrorMessage } from '@/composables/useAuthFetch'
+import { useAuthStore } from '@/stores/auth'
 import { API } from '@/config'
 
 const { authFetchJson } = useAuthFetch()
+const authStore = useAuthStore()
 
 // ═══ 翻译区 ═══
 const direction = ref('zh2en')
@@ -18,6 +20,7 @@ const source = ref('')
 const translated = ref('')
 const translating = ref(false)
 const error = ref('')
+const savedToVocab = ref(false)
 
 const MAX_LEN = 1000
 const canSubmit = computed(
@@ -29,32 +32,18 @@ async function onTranslate() {
   translating.value = true
   error.value = ''
   translated.value = ''
+  savedToVocab.value = false
   try {
     const data = await authFetchJson(`${API.TRANSLATE}/text`, {
       text: source.value,
       direction: direction.value,
     })
     translated.value = data.translated_text || ''
+    savedToVocab.value = !!data.saved_to_vocab
   } catch (err) {
     error.value = getErrorMessage(err, '翻译失败')
   } finally {
     translating.value = false
-  }
-}
-
-async function onSave() {
-  if (!translated.value.trim()) return
-  try {
-    await authFetchJson(`${API.TRANSLATE}/vocabulary`, {
-      source_text: source.value,
-      translated_text: translated.value,
-      direction: direction.value,
-    })
-    _toast('⭐ 已加入生词本', 'success')
-  } catch (err) {
-    const msg = getErrorMessage(err)
-    error.value = msg
-    if (msg) _toast(msg, 'error')
   }
 }
 
@@ -82,6 +71,15 @@ function _toast(text, type = 'info', duration = 1800) {
       </button>
     </header>
 
+    <div class="capability-banner">
+      <template v-if="authStore.isAuthenticated">
+        ✨ 翻译过的内容会自动加入生词本
+      </template>
+      <template v-else>
+        ✨ 登录后翻译会自动加入生词本 <RouterLink to="/login">去登录</RouterLink>
+      </template>
+    </div>
+
     <main class="body">
       <!-- 翻译区 -->
       <section class="pair">
@@ -97,7 +95,9 @@ function _toast(text, type = 'info', duration = 1800) {
           <div class="result" :class="{ loading: translating }">
             {{ translated || (translating ? '翻译中...' : '译文会显示在这里') }}
           </div>
-          <button v-if="translated" class="save" @click="onSave">⭐ 收藏到生词本</button>
+          <div v-if="savedToVocab && authStore.isAuthenticated" class="vocab-status">
+            ⭐ 已加入生词本 · <RouterLink to="/vocabulary">查看生词本 →</RouterLink>
+          </div>
         </div>
       </section>
 
@@ -196,20 +196,26 @@ textarea {
   color: var(--text-3);
   text-align: right;
 }
-.save {
-  align-self: flex-start;
-  padding: 6px var(--space-3);
-  background: var(--accent-soft);
-  color: var(--accent);
-  border-radius: var(--radius-sm);
+.capability-banner {
+  text-align: center;
+  padding: var(--space-2) var(--space-4);
   font-size: 13px;
-  font-weight: 500;
-  transition: all var(--duration) var(--ease);
+  color: var(--text-2);
+  background: var(--bg-elevated);
+  border-bottom: 1px solid var(--border);
 }
-.save:active {
-  background: var(--accent);
-  color: var(--text-inverse);
-  transform: scale(0.96);
+.capability-banner a {
+  color: var(--accent);
+  text-decoration: underline;
+}
+.vocab-status {
+  font-size: 13px;
+  color: var(--accent);
+  padding: var(--space-1) 0;
+}
+.vocab-status a {
+  color: var(--accent);
+  text-decoration: underline;
 }
 .primary {
   width: 100%;

--- a/tests/test_translate_auto_vocab.py
+++ b/tests/test_translate_auto_vocab.py
@@ -1,0 +1,183 @@
+"""Translate 自动入生词本 — 翻译即占位 + 回填
+user_id: test_user_translate_autovocab_*
+"""
+import pytest
+from unittest.mock import patch, AsyncMock
+from httpx import AsyncClient, ASGITransport
+from sqlalchemy.orm import Session as OrmSession
+
+from main import app
+from app.models.db import engine, Base, Vocabulary
+from app.routers.auth import get_current_user_id_optional
+
+USER = "test_user_translate_autovocab"
+TRANSLATED_MOCK = "Hello World"
+
+
+@pytest.fixture(autouse=True)
+def cleanup():
+    Base.metadata.create_all(engine)
+    with OrmSession(engine) as s:
+        s.query(Vocabulary).filter(Vocabulary.user_id.like("test_user_translate_autovocab%")).delete(synchronize_session=False)
+        s.commit()
+    yield
+    with OrmSession(engine) as s:
+        s.query(Vocabulary).filter(Vocabulary.user_id.like("test_user_translate_autovocab%")).delete(synchronize_session=False)
+        s.commit()
+    app.dependency_overrides.pop(get_current_user_id_optional, None)
+
+
+def _override_user(uid):
+    app.dependency_overrides[get_current_user_id_optional] = lambda: uid
+
+
+def _override_anon():
+    app.dependency_overrides[get_current_user_id_optional] = lambda: None
+
+
+def _count_vocab(user_id):
+    with OrmSession(engine) as s:
+        return s.query(Vocabulary).filter_by(user_id=user_id).count()
+
+
+def _get_vocab(user_id):
+    with OrmSession(engine) as s:
+        rows = s.query(Vocabulary).filter_by(user_id=user_id).all()
+        return [{"id": r.id, "source_text": r.source_text, "translated_text": r.translated_text,
+                 "status": r.status, "item_type": r.item_type, "source_type": r.source_type} for r in rows]
+
+
+@pytest.mark.asyncio
+async def test_anonymous_translate_no_vocab():
+    _override_anon()
+    with patch("app.routers.translate.translate_text", new_callable=AsyncMock, return_value=TRANSLATED_MOCK):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post("/translate/text", json={"text": "你好世界", "direction": "zh2en"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["translated_text"] == TRANSLATED_MOCK
+    assert data["saved_to_vocab"] is False
+    assert data["vocab_id"] is None
+    assert _count_vocab(USER) == 0
+
+
+@pytest.mark.asyncio
+async def test_logged_in_translate_creates_vocab():
+    _override_user(USER)
+    with patch("app.routers.translate.translate_text", new_callable=AsyncMock, return_value=TRANSLATED_MOCK):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post("/translate/text", json={"text": "你好世界", "direction": "zh2en"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["saved_to_vocab"] is True
+    assert data["vocab_id"] is not None
+
+    rows = _get_vocab(USER)
+    assert len(rows) == 1
+    assert rows[0]["source_text"] == "你好世界"
+    assert rows[0]["translated_text"] == TRANSLATED_MOCK
+    assert rows[0]["item_type"] == "sentence"
+    assert rows[0]["source_type"] == "translate"
+
+
+@pytest.mark.asyncio
+async def test_logged_in_translate_idempotent():
+    _override_user(USER)
+    with patch("app.routers.translate.translate_text", new_callable=AsyncMock, return_value="First"):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            r1 = await c.post("/translate/text", json={"text": "重复文本", "direction": "zh2en"})
+
+    with patch("app.routers.translate.translate_text", new_callable=AsyncMock, return_value="Second"):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            r2 = await c.post("/translate/text", json={"text": "重复文本", "direction": "zh2en"})
+
+    assert r1.json()["vocab_id"] == r2.json()["vocab_id"]
+    rows = _get_vocab(USER)
+    assert len(rows) == 1
+    assert rows[0]["translated_text"] == "Second"  # force=True 覆盖
+
+
+@pytest.mark.asyncio
+async def test_logged_in_translate_resurrects_deleted():
+    _override_user(USER)
+    # 先创建并软删
+    with patch("app.routers.translate.translate_text", new_callable=AsyncMock, return_value="v1"):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            r1 = await c.post("/translate/text", json={"text": "删除测试", "direction": "zh2en"})
+    vid = r1.json()["vocab_id"]
+
+    # 软删
+    with OrmSession(engine) as s:
+        v = s.query(Vocabulary).filter_by(id=vid).first()
+        v.status = "deleted"
+        s.commit()
+
+    # 再翻译同一文本
+    with patch("app.routers.translate.translate_text", new_callable=AsyncMock, return_value="v2"):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            r2 = await c.post("/translate/text", json={"text": "删除测试", "direction": "zh2en"})
+
+    assert r2.json()["saved_to_vocab"] is True
+    rows = _get_vocab(USER)
+    assert len(rows) == 1
+    assert rows[0]["status"] == "active"
+    assert rows[0]["translated_text"] == "v2"
+
+
+@pytest.mark.asyncio
+async def test_translate_failure_keeps_placeholder():
+    _override_user(USER)
+    with patch("app.routers.translate.translate_text", new_callable=AsyncMock, side_effect=Exception("LLM boom")):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post("/translate/text", json={"text": "爆炸", "direction": "zh2en"})
+    assert resp.status_code == 503
+    # 占位条目仍在
+    rows = _get_vocab(USER)
+    assert len(rows) == 1
+    assert rows[0]["translated_text"] == ""
+
+
+@pytest.mark.asyncio
+async def test_invalid_token_falls_back_anonymous():
+    # Don't override dependency — let it be None (anonymous)
+    _override_anon()
+    with patch("app.routers.translate.translate_text", new_callable=AsyncMock, return_value=TRANSLATED_MOCK):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post("/translate/text", json={"text": "匿名测试", "direction": "zh2en"})
+    assert resp.status_code == 200
+    assert resp.json()["saved_to_vocab"] is False
+
+
+@pytest.mark.asyncio
+async def test_save_placeholder_failure_degrades():
+    _override_user(USER)
+    with patch("app.routers.translate.translate_text", new_callable=AsyncMock, return_value=TRANSLATED_MOCK), \
+         patch("app.routers.translate.save_item", side_effect=Exception("DB boom")):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post("/translate/text", json={"text": "降级", "direction": "zh2en"})
+    assert resp.status_code == 200
+    assert resp.json()["translated_text"] == TRANSLATED_MOCK
+    assert resp.json()["saved_to_vocab"] is False
+
+
+@pytest.mark.asyncio
+async def test_backfill_failure_degrades():
+    _override_user(USER)
+    with patch("app.routers.translate.translate_text", new_callable=AsyncMock, return_value=TRANSLATED_MOCK), \
+         patch("app.routers.translate.update_translated_text", side_effect=Exception("backfill boom")):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post("/translate/text", json={"text": "回填失败", "direction": "zh2en"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["translated_text"] == TRANSLATED_MOCK
+    assert data["saved_to_vocab"] is True  # 占位成功
+    assert data["vocab_id"] is not None
+
+
+@pytest.mark.asyncio
+async def test_invalid_direction_no_placeholder():
+    _override_user(USER)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        resp = await c.post("/translate/text", json={"text": "方向错误", "direction": "xx"})
+    assert resp.status_code == 400
+    assert _count_vocab(USER) == 0


### PR DESCRIPTION
## Summary
- 登录用户点翻译即自动写入 vocabulary，无需手动收藏
- 后端: `do_translate` 接受可选 JWT，翻译前占位写入 vocabulary，成功后回填 `translated_text`
- 后端: `vocab_service.update_translated_text()` 新增回填函数
- 前端: 删除手动「⭐ 收藏到生词本」按钮，改为自动状态提示 + 能力说明条
- 修复: `model_client.py` `float|None` → `Optional[float]` (Python 3.9 兼容)

实现 spec: `docs/superpowers/specs/2026-05-20-translate-auto-vocab-design.md`

## Test plan
- [x] 9 个新测试全通过 (`tests/test_translate_auto_vocab.py`)
- [x] 翻译批量测试回归全通过 (`tests/test_v05_translate_batch.py`)
- [ ] 手动验证: 登录态翻译后显示「⭐ 已加入生词本」
- [ ] 手动验证: 匿名态翻译正常，无生词本提示

🤖 Generated with [Claude Code](https://claude.com/claude-code)