### PR TITLE
feat(library): /library 模块 — 用户技术文档精读 (V0.8)

### DIFF
--- a/app/models/db.py
+++ b/app/models/db.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Optional, List
 from sqlalchemy import (
     String, ForeignKey, func,
-    Column, Integer, Boolean, DateTime, UniqueConstraint, create_engine,
+    Column, Integer, Boolean, DateTime, Text, UniqueConstraint, create_engine,
 )
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
@@ -159,8 +159,9 @@ class Vocabulary(Base):
     status           = Column(String, nullable=False, default="active")  # active | deleted
     # ── V0.10 生词本 + FSRS（P1）──────────────────────────────
     item_type        = Column(String, nullable=False, default="sentence")  # word | phrase | sentence
-    source_type      = Column(String, nullable=False, default="translate") # translate | bbc_eaw | practice | chat
-    source_ref       = Column(String, nullable=True)                       # bbc slug / session_id / null
+    source_type      = Column(String, nullable=False, default="translate") # translate | article | practice | chat
+    source_ref       = Column(String, nullable=True)                       # episode slug / session_id / null
+    series           = Column(String, nullable=True)                       # bbc_eaw | voa | ... (when source_type='article')
     explanation_json = Column(String, nullable=True)                       # 复用 ExplanationCache 输出
     fsrs_card_data   = Column(String, nullable=False, default="")
     last_reviewed_at = Column(DateTime, nullable=True)
@@ -228,14 +229,15 @@ class AskMessage(Base):
     created_at = Column(DateTime, default=datetime.utcnow)
 
 
-# ── 公共素材：BBC Learning English / English at Work ────────
-# 67 集，每集一行；不绑 user_id（全用户共享）
+# ── 公共素材：文章系列（BBC EAW / VOA / ...）────────
+# 每集一行；不绑 user_id（全用户共享）
 # 灌库脚本：scripts/bbc_eaw_seed.py（数据来源 data/bbc_eaw/parsed/）
 
-class BbcEawEpisode(Base):
-    __tablename__ = "bbc_eaw_episodes"
+class ArticleEpisode(Base):
+    __tablename__ = "article_episodes"
 
     id                 = Column(Integer, primary_key=True, autoincrement=True)
+    series             = Column(String, nullable=False, default="bbc_eaw")  # bbc_eaw | voa | ...
     slug               = Column(String, nullable=False, unique=True)   # 01-the-interview
     url                = Column(String, nullable=False)
     title              = Column(String, nullable=True)                 # The Interview
@@ -262,7 +264,7 @@ class BbcArticleCard(Base):
 
     id               = Column(Integer, primary_key=True, autoincrement=True)
     user_id          = Column(String, nullable=False, index=True)
-    slug             = Column(String, nullable=False, index=True)         # 关联 BbcEawEpisode.slug
+    slug             = Column(String, nullable=False, index=True)         # 关联 ArticleEpisode.slug
     fsrs_card_data   = Column(String, nullable=False, default="")
     status           = Column(String, nullable=False, default="active")   # active | deleted
     first_studied_at = Column(DateTime, default=datetime.utcnow)
@@ -328,6 +330,27 @@ class LlmCallLog(Base):
     created_at     = Column(DateTime, default=datetime.utcnow)
 
 
+# ── V0.8 用户文章库 ────────────────────────────────────────
+
+class LibraryArticle(Base):
+    __tablename__ = "library_articles"
+
+    id          = Column(Integer, primary_key=True, autoincrement=True)
+    user_id     = Column(String, nullable=False, index=True)
+    source_url  = Column(String, nullable=True)
+    title       = Column(String, nullable=False)
+    markdown    = Column(Text, nullable=False)
+    word_count  = Column(Integer, nullable=False, default=0)
+    source_meta = Column(Text, nullable=True)   # JSON string
+    status      = Column(String, nullable=False, default="active")  # active | deleted
+    created_at  = Column(DateTime, default=func.now())
+    updated_at  = Column(DateTime, default=func.now(), onupdate=func.now())
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "source_url", name="ux_library_articles_user_url"),
+    )
+
+
 # Sync engine for ORM operations (tests, memory_service, review_service)
 import os as _os
 _DB_PATH = _os.environ.get("SPEAKEASY_DB_PATH", "./speakeasy.db")
@@ -336,3 +359,8 @@ engine = create_engine(
     connect_args={"check_same_thread": False},
 )
 Base.metadata.create_all(engine)
+
+
+def init_db():
+    """Create all tables (idempotent). Convenience wrapper for tests."""
+    Base.metadata.create_all(engine)

--- a/app/routers/library.py
+++ b/app/routers/library.py
@@ -1,0 +1,358 @@
+"""文章库路由 — /library/articles 及解读端点"""
+
+import json
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Query, Depends
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+
+from app.routers.auth import get_current_user_id, get_current_user_id_optional
+from app.services import library_service
+from app.services.explain_service import explain_text, quick_phonetic, stream_sentence_explanation
+from app.services import vocab_service as _vocab_service
+from app.logger import get_logger
+
+logger = get_logger("library")
+
+router = APIRouter(prefix="/library")
+
+
+# ── Schemas ────────────────────────────────────────────────
+
+class ImportArticleRequest(BaseModel):
+    url: Optional[str] = None
+    markdown: Optional[str] = None
+    title: Optional[str] = None
+
+
+class ExplainRequest(BaseModel):
+    text: str
+    kind: str                          # 'sentence' | 'word'
+    context: Optional[str] = ""
+    refresh: bool = False
+
+
+class QuickPhoneticRequest(BaseModel):
+    text: str
+    item_type: Optional[str] = None    # 'word' | 'phrase' — 前端推断后传入
+
+
+class StreamExplainRequest(BaseModel):
+    text: str
+    refresh: bool = False
+    context: Optional[str] = ""
+    item_type: Optional[str] = None
+
+
+# ── 工具函数 ───────────────────────────────────────────────
+
+def _resolve_item_type(text: str, explicit: Optional[str], kind: str) -> str:
+    if explicit in ("word", "phrase", "sentence"):
+        return explicit
+    if kind == "word":
+        tokens = (text or "").strip().split()
+        return "word" if len(tokens) <= 1 else "phrase"
+    return "sentence"
+
+
+def _auto_save_library_vocab(
+    user_id: str,
+    article_id: int,
+    text: str,
+    context: Optional[str],
+    item_type: str,
+) -> None:
+    """解读发起时占位写入 vocabulary（explanation_json=None）。失败仅 warning，不向上抛。"""
+    if not text or not text.strip():
+        return
+    try:
+        _vocab_service.save_item(
+            user_id=user_id,
+            source_text=text,
+            translated_text="",
+            direction="en2zh",
+            context=context or None,
+            item_type=item_type,
+            source_type="library",
+            source_ref=str(article_id),
+            explanation_json=None,
+        )
+        logger.info(
+            "library_vocab_auto_save user_id=%s article_id=%d text=%s item_type=%s",
+            user_id, article_id, text[:40], item_type,
+        )
+    except Exception as e:
+        logger.warning(
+            "library_vocab_auto_save_failed user_id=%s article_id=%d text=%s err=%s",
+            user_id, article_id, text[:40], e,
+        )
+
+
+def _backfill_library_vocab(
+    user_id: str,
+    article_id: int,
+    text: str,
+    explanation_json: str,
+    force: bool = False,
+) -> None:
+    """解读完成后回填 explanation_json。失败仅 warning，不向上抛。"""
+    try:
+        _vocab_service.update_explanation(
+            user_id=user_id,
+            source_text=text,
+            source_ref=str(article_id),
+            explanation_json=explanation_json,
+            force=force,
+        )
+        logger.info(
+            "library_vocab_backfill user_id=%s article_id=%d text=%s",
+            user_id, article_id, text[:40],
+        )
+    except Exception as e:
+        logger.warning(
+            "library_vocab_backfill_failed user_id=%s article_id=%d text=%s err=%s",
+            user_id, article_id, text[:40], e,
+        )
+
+
+def _get_article_or_404(article_id: int, user_id: str):
+    """Get article or raise 404."""
+    article = library_service.get_article(article_id, user_id)
+    if article is None:
+        raise HTTPException(404, "文章不存在或已删除")
+    return article
+
+
+# ── CRUD 端点 ──────────────────────────────────────────────
+
+@router.post("/articles", status_code=201)
+async def import_article(
+    req: ImportArticleRequest,
+    user_id: str = Depends(get_current_user_id),
+):
+    """导入文章：URL 模式或粘贴 Markdown 模式。
+
+    URL 命中已存条目 → 200 + {existing: true, ...}
+    新条目 → 201 + 完整记录
+    """
+    if not req.url and not req.markdown:
+        raise HTTPException(400, "url 或 markdown 必须提供其一")
+
+    try:
+        result = library_service.import_article(
+            user_id=user_id,
+            url=req.url or None,
+            markdown=req.markdown or None,
+            title=req.title or None,
+        )
+    except ValueError as e:
+        err_str = str(e)
+        if "fetch_failed" in err_str:
+            raise HTTPException(
+                400,
+                detail={
+                    "error": "fetch_failed",
+                    "hint": "抓取失败，请改用粘贴正文模式",
+                },
+            )
+        raise HTTPException(400, err_str)
+    except Exception as e:
+        logger.error("import_article error: %s", e, exc_info=True)
+        raise HTTPException(503, "导入失败，请稍后重试")
+
+    # 已存在时返回 200
+    if result.get("existing"):
+        from fastapi.responses import JSONResponse
+        return JSONResponse(status_code=200, content=result)
+
+    return result
+
+
+@router.get("/articles")
+async def list_articles(
+    user_id: str = Depends(get_current_user_id),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+):
+    articles = library_service.list_articles(user_id, page=page, page_size=page_size)
+    return {"articles": articles, "page": page, "page_size": page_size}
+
+
+@router.get("/articles/{article_id}")
+async def get_article(
+    article_id: int,
+    user_id: str = Depends(get_current_user_id),
+):
+    return _get_article_or_404(article_id, user_id)
+
+
+@router.delete("/articles/{article_id}")
+async def delete_article(
+    article_id: int,
+    user_id: str = Depends(get_current_user_id),
+):
+    ok = library_service.delete_article(article_id, user_id)
+    if not ok:
+        raise HTTPException(404, "文章不存在或已删除")
+    return {"deleted": True, "id": article_id}
+
+
+@router.post("/articles/{article_id}/refetch")
+async def refetch_article(
+    article_id: int,
+    user_id: str = Depends(get_current_user_id),
+):
+    try:
+        result = library_service.refetch_article(article_id, user_id)
+    except LookupError as e:
+        raise HTTPException(404, str(e))
+    except ValueError as e:
+        err_str = str(e)
+        if "paste_mode_no_url" in err_str:
+            raise HTTPException(400, "粘贴正文模式的文章无法重新抓取")
+        if "fetch_failed" in err_str:
+            raise HTTPException(
+                400,
+                detail={
+                    "error": "fetch_failed",
+                    "hint": "抓取失败，请改用粘贴正文模式",
+                },
+            )
+        raise HTTPException(400, err_str)
+    except Exception as e:
+        logger.error("refetch_article error: %s", e, exc_info=True)
+        raise HTTPException(503, "重新抓取失败，请稍后重试")
+    return result
+
+
+# ── 解读端点 ───────────────────────────────────────────────
+
+@router.post("/articles/{article_id}/explain")
+async def library_explain(
+    article_id: int,
+    req: ExplainRequest,
+    user_id: str = Depends(get_current_user_id),
+):
+    """词/句解读，发起即占位写入 vocabulary，完成后回填 explanation_json。"""
+    # 确认文章存在（归属校验）
+    _get_article_or_404(article_id, user_id)
+
+    item_type = _resolve_item_type(req.text, None, req.kind)
+
+    # 入口占位写入
+    _auto_save_library_vocab(
+        user_id=user_id,
+        article_id=article_id,
+        text=req.text,
+        context=req.context or None,
+        item_type=item_type,
+    )
+
+    try:
+        result = await explain_text(
+            text=req.text,
+            kind=req.kind,
+            user_id=user_id,
+            context=req.context or "",
+            force=req.refresh,
+        )
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+    except Exception as e:
+        logger.error("library_explain error: %s", e, exc_info=True)
+        raise HTTPException(503, "解读服务暂时不可用，请稍后重试")
+
+    # 回填
+    if result.get("explanation"):
+        _backfill_library_vocab(
+            user_id=user_id,
+            article_id=article_id,
+            text=req.text,
+            explanation_json=json.dumps(result["explanation"], ensure_ascii=False),
+            force=req.refresh,
+        )
+
+    return result
+
+
+@router.post("/articles/{article_id}/explain/phonetic")
+async def library_explain_phonetic(
+    article_id: int,
+    req: QuickPhoneticRequest,
+    user_id: Optional[str] = Depends(get_current_user_id_optional),
+):
+    """单词 IPA 秒出；占位写入 vocabulary。"""
+    if not req.text or not req.text.strip():
+        raise HTTPException(400, "text is required")
+
+    if user_id:
+        item_type = _resolve_item_type(req.text, req.item_type, "word")
+        _auto_save_library_vocab(
+            user_id=user_id,
+            article_id=article_id,
+            text=req.text,
+            context=None,
+            item_type=item_type,
+        )
+
+    return {"phonetic": quick_phonetic(req.text)}
+
+
+@router.post("/articles/{article_id}/explain/stream")
+async def library_explain_stream(
+    article_id: int,
+    req: StreamExplainRequest,
+    user_id: str = Depends(get_current_user_id),
+):
+    """句子解读流式接口（NDJSON）。入口占位写入，流完成后回填。"""
+    if not req.text or not req.text.strip():
+        raise HTTPException(400, "text is required")
+
+    # 确认文章存在
+    _get_article_or_404(article_id, user_id)
+
+    item_type = _resolve_item_type(req.text, req.item_type, "sentence")
+
+    # 入口占位写入
+    _auto_save_library_vocab(
+        user_id=user_id,
+        article_id=article_id,
+        text=req.text,
+        context=req.context or None,
+        item_type=item_type,
+    )
+
+    async def event_stream():
+        collected: dict = {}
+        try:
+            async for line in stream_sentence_explanation(req.text, user_id, force=req.refresh):
+                try:
+                    evt = json.loads(line)
+                except Exception:
+                    evt = None
+                if isinstance(evt, dict):
+                    if evt.get("_cached") and isinstance(evt.get("explanation"), dict):
+                        collected = dict(evt["explanation"])
+                    elif "field" in evt and "value" in evt:
+                        collected[evt["field"]] = evt["value"]
+                yield line + "\n"
+        except ValueError as e:
+            yield json.dumps({"_error": str(e)}, ensure_ascii=False) + "\n"
+            return
+        except Exception as e:
+            logger.error("library stream explain error: %s", e, exc_info=True)
+            yield json.dumps({"_error": "解读服务暂时不可用"}, ensure_ascii=False) + "\n"
+            return
+
+        # 流末尾回填
+        if collected:
+            _backfill_library_vocab(
+                user_id=user_id,
+                article_id=article_id,
+                text=req.text,
+                explanation_json=json.dumps(collected, ensure_ascii=False),
+                force=req.refresh,
+            )
+
+    return StreamingResponse(event_stream(), media_type="application/x-ndjson")

--- a/app/services/library_service.py
+++ b/app/services/library_service.py
@@ -1,0 +1,285 @@
+"""文章库服务 — 用户自带技术文档的导入、管理与列表
+
+支持两种导入方式：
+  - URL 模式：trafilatura 提取正文 Markdown + meta
+  - Markdown 模式：直接粘贴正文
+"""
+import json
+import logging
+from typing import Dict, List, Optional
+
+from sqlalchemy import func as sql_func
+from sqlalchemy.orm import Session as OrmSession
+from sqlalchemy.exc import IntegrityError
+
+from app.models.db import engine, LibraryArticle, Vocabulary
+from app.logger import get_logger
+
+logger = get_logger("library_service")
+
+MAX_MARKDOWN_LEN = 100_000
+
+
+def _extract_from_url(url: str):
+    """Extract markdown + meta from URL using trafilatura.
+
+    Returns (markdown: str, meta: dict).
+    Raises ValueError("fetch_failed") on any failure.
+    """
+    try:
+        import trafilatura
+    except ImportError:
+        raise ValueError("trafilatura not installed")
+
+    downloaded = trafilatura.fetch_url(url)
+    if not downloaded:
+        raise ValueError("fetch_failed")
+
+    result = trafilatura.extract(
+        downloaded,
+        output_format="markdown",
+        include_links=True,
+        include_tables=True,
+        with_metadata=True,
+    )
+    if not result:
+        raise ValueError("fetch_failed")
+
+    meta = {}
+    try:
+        meta_obj = trafilatura.extract_metadata(downloaded)
+        if meta_obj:
+            meta = {
+                "author": meta_obj.author,
+                "site_name": meta_obj.sitename,
+                "title": meta_obj.title,
+            }
+    except Exception:
+        pass
+
+    return result, meta
+
+
+def _title_from_markdown(markdown: str) -> Optional[str]:
+    """Extract first # heading from markdown as title fallback."""
+    for line in markdown.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("# "):
+            return stripped[2:].strip()
+    return None
+
+
+def _article_to_dict(article: LibraryArticle, vocab_count: int = 0) -> Dict:
+    return {
+        "id": article.id,
+        "user_id": article.user_id,
+        "source_url": article.source_url,
+        "title": article.title,
+        "markdown": article.markdown,
+        "word_count": article.word_count,
+        "source_meta": json.loads(article.source_meta) if article.source_meta else {},
+        "status": article.status,
+        "vocab_count": vocab_count,
+        "created_at": article.created_at.isoformat() if article.created_at else None,
+        "updated_at": article.updated_at.isoformat() if article.updated_at else None,
+    }
+
+
+def import_article(
+    user_id: str,
+    url: Optional[str] = None,
+    markdown: Optional[str] = None,
+    title: Optional[str] = None,
+) -> Dict:
+    """Import an article (URL or paste-markdown mode).
+
+    URL dedup: if (user_id, source_url) already exists, return existing with existing=True.
+    Returns dict with extra key 'existing' (bool).
+    """
+    if not url and not markdown:
+        raise ValueError("url 或 markdown 必须提供其一")
+
+    source_meta: Dict = {}
+
+    if url:
+        # Check dedup first (before fetching)
+        with OrmSession(engine) as s:
+            existing = (
+                s.query(LibraryArticle)
+                .filter_by(user_id=user_id, source_url=url)
+                .first()
+            )
+            if existing:
+                logger.info(
+                    "library_article_dedup_hit user_id=%s url=%s id=%d",
+                    user_id, url, existing.id,
+                )
+                result = _article_to_dict(existing, _count_vocab(s, user_id, existing.id))
+                result["existing"] = True
+                return result
+
+        # Fetch URL
+        try:
+            markdown, source_meta = _extract_from_url(url)
+        except ValueError as e:
+            logger.warning("library_article_fetch_failed user_id=%s url=%s reason=%s", user_id, url, e)
+            raise
+
+        # Title: meta > first # heading > Untitled
+        if not title:
+            title = source_meta.get("title") or _title_from_markdown(markdown) or "Untitled"
+    else:
+        # Paste mode: title required by caller, but provide fallback
+        if not title:
+            title = _title_from_markdown(markdown) or "Untitled"
+
+    # Truncate if too long
+    truncated = False
+    if len(markdown) > MAX_MARKDOWN_LEN:
+        markdown = markdown[:MAX_MARKDOWN_LEN]
+        truncated = True
+        logger.warning(
+            "library_article_truncated user_id=%s url=%s char_count=%d",
+            user_id, url, MAX_MARKDOWN_LEN,
+        )
+        source_meta["truncated"] = True
+
+    word_count = len(markdown.split())
+
+    with OrmSession(engine) as s:
+        article = LibraryArticle(
+            user_id=user_id,
+            source_url=url or None,
+            title=title,
+            markdown=markdown,
+            word_count=word_count,
+            source_meta=json.dumps(source_meta, ensure_ascii=False) if source_meta else None,
+            status="active",
+        )
+        s.add(article)
+        try:
+            s.commit()
+        except IntegrityError:
+            s.rollback()
+            # Race condition: another request inserted the same URL
+            existing = (
+                s.query(LibraryArticle)
+                .filter_by(user_id=user_id, source_url=url)
+                .first()
+            )
+            if existing:
+                result = _article_to_dict(existing, _count_vocab(s, user_id, existing.id))
+                result["existing"] = True
+                return result
+            raise
+        s.refresh(article)
+        logger.info(
+            "library_article_imported user_id=%s id=%d mode=%s char_count=%d",
+            user_id, article.id, "url" if url else "markdown", len(markdown),
+        )
+        result = _article_to_dict(article, 0)
+        result["existing"] = False
+        return result
+
+
+def _count_vocab(session: OrmSession, user_id: str, article_id: int) -> int:
+    """Count vocabulary items for this article."""
+    count = (
+        session.query(sql_func.count(Vocabulary.id))
+        .filter_by(user_id=user_id, source_type="library", source_ref=str(article_id))
+        .scalar()
+    )
+    return count or 0
+
+
+def list_articles(
+    user_id: str,
+    page: int = 1,
+    page_size: int = 20,
+) -> List[Dict]:
+    """List active articles for user, ordered by created_at DESC, with vocab_count."""
+    offset = (page - 1) * page_size
+    with OrmSession(engine) as s:
+        rows = (
+            s.query(LibraryArticle)
+            .filter_by(user_id=user_id, status="active")
+            .order_by(LibraryArticle.created_at.desc())
+            .offset(offset)
+            .limit(page_size)
+            .all()
+        )
+        result = []
+        for article in rows:
+            d = _article_to_dict(article, _count_vocab(s, user_id, article.id))
+            # Don't include full markdown in list (bandwidth)
+            d.pop("markdown", None)
+            result.append(d)
+        return result
+
+
+def get_article(article_id: int, user_id: str) -> Optional[Dict]:
+    """Get article detail (including full markdown) with vocab_count."""
+    with OrmSession(engine) as s:
+        article = (
+            s.query(LibraryArticle)
+            .filter_by(id=article_id, user_id=user_id, status="active")
+            .first()
+        )
+        if not article:
+            return None
+        return _article_to_dict(article, _count_vocab(s, user_id, article.id))
+
+
+def delete_article(article_id: int, user_id: str) -> bool:
+    """Soft delete article. vocabulary items are NOT cascade-deleted."""
+    with OrmSession(engine) as s:
+        article = (
+            s.query(LibraryArticle)
+            .filter_by(id=article_id, user_id=user_id, status="active")
+            .first()
+        )
+        if not article:
+            return False
+        article.status = "deleted"
+        s.commit()
+        return True
+
+
+def refetch_article(article_id: int, user_id: str) -> Dict:
+    """Re-extract content from URL. Only valid for URL-based articles."""
+    with OrmSession(engine) as s:
+        article = (
+            s.query(LibraryArticle)
+            .filter_by(id=article_id, user_id=user_id, status="active")
+            .first()
+        )
+        if not article:
+            raise LookupError("文章不存在或已删除")
+        if not article.source_url:
+            raise ValueError("paste_mode_no_url")
+
+        try:
+            markdown, source_meta = _extract_from_url(article.source_url)
+        except ValueError as e:
+            logger.warning(
+                "library_article_fetch_failed user_id=%s url=%s reason=%s",
+                user_id, article.source_url, e,
+            )
+            raise
+
+        truncated = False
+        if len(markdown) > MAX_MARKDOWN_LEN:
+            markdown = markdown[:MAX_MARKDOWN_LEN]
+            source_meta["truncated"] = True
+            logger.warning(
+                "library_article_truncated user_id=%s url=%s",
+                user_id, article.source_url,
+            )
+
+        article.markdown = markdown
+        article.word_count = len(markdown.split())
+        if source_meta:
+            article.source_meta = json.dumps(source_meta, ensure_ascii=False)
+        s.commit()
+        s.refresh(article)
+        return _article_to_dict(article, _count_vocab(s, user_id, article.id))

--- a/app/services/vocab_service.py
+++ b/app/services/vocab_service.py
@@ -25,7 +25,7 @@ from app.logger import get_logger
 logger = get_logger("vocab_service")
 
 VALID_ITEM_TYPES = {"word", "phrase", "sentence"}
-VALID_SOURCE_TYPES = {"translate", "bbc_eaw", "practice", "chat"}
+VALID_SOURCE_TYPES = {"translate", "article", "practice", "chat", "library"}
 
 
 def _to_dict(v: Vocabulary) -> Dict:
@@ -39,6 +39,7 @@ def _to_dict(v: Vocabulary) -> Dict:
         "item_type": v.item_type,
         "source_type": v.source_type,
         "source_ref": v.source_ref,
+        "series": v.series,
         "explanation_json": v.explanation_json,
         "status": v.status,
         "created_at": v.created_at.isoformat() if v.created_at else None,
@@ -58,6 +59,7 @@ def save_item(
     source_type: str = "translate",
     source_ref: Optional[str] = None,
     explanation_json: Optional[str] = None,
+    series: Optional[str] = None,
 ) -> Dict:
     """新增或返回已存在条目（去重键: user_id + source_text + source_ref）"""
     if not source_text or not source_text.strip():
@@ -91,6 +93,7 @@ def save_item(
             item_type=item_type,
             source_type=source_type,
             source_ref=source_ref,
+            series=series,
             explanation_json=explanation_json,
             fsrs_card_data=create_card(),
             status="active",
@@ -225,8 +228,9 @@ def bulk_save_from_bbc(
             direction="en2zh",
             context=seg.get("context"),
             item_type="sentence",
-            source_type="bbc_eaw",
+            source_type="article",
             source_ref=slug,
+            series="bbc_eaw",
         )
         # 粗略判定：刚创建的 last_reviewed_at 必为 None
         if item.get("last_reviewed_at") is None:

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -15,6 +15,7 @@ export const API = {
   MEMORY: '/memory',
   PRACTICE: '/practice',
   ARTICLES: '/articles',  // V0.8：文章学习模块新名；后端 /practice/* alias 仍在
+  LIBRARY: '/library',   // V0.8：用户文章库
   TRANSLATE: '/translate',
   VOCAB: '/vocab',
   POLISH: '/polish',

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -71,6 +71,18 @@ const router = createRouter({
       component: BbcArticleReview,
       meta: { requiresAuth: true },
     },
+    {
+      path: '/library',
+      name: 'library',
+      component: () => import('@/views/Library.vue'),
+      meta: { requiresAuth: true },
+    },
+    {
+      path: '/library/:id',
+      name: 'library-article',
+      component: () => import('@/views/LibraryArticle.vue'),
+      meta: { requiresAuth: true },
+    },
     { path: '/login', name: 'login', component: Login, meta: { requiresAuth: false } },
     { path: '/:pathMatch(.*)*', name: 'not-found', component: NotFound },
   ],

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -149,6 +149,10 @@ onMounted(() => {
         <span class="ico">🎧</span>
         <span class="name">文章学习</span>
       </RouterLink>
+      <RouterLink to="/library" class="sec-item">
+        <span class="ico">📚</span>
+        <span class="name">文章库</span>
+      </RouterLink>
       <RouterLink to="/translate" class="sec-item">
         <span class="ico">🌐</span>
         <span class="name">翻译</span>

--- a/frontend/src/views/Library.vue
+++ b/frontend/src/views/Library.vue
@@ -1,0 +1,524 @@
+<template>
+  <div class="library-page">
+    <header class="library-header">
+      <div class="library-header-inner">
+        <div class="library-title-row">
+          <h1>我的文章库</h1>
+          <button class="btn-add" @click="showModal = true">+ 添加文章</button>
+        </div>
+      </div>
+    </header>
+
+    <main class="library-main">
+      <div v-if="loading" class="library-loading">加载中...</div>
+      <div v-else-if="articles.length === 0" class="library-empty">
+        <p>暂无文章，点击右上角「添加文章」导入第一篇</p>
+      </div>
+      <ul v-else class="article-list">
+        <li
+          v-for="article in articles"
+          :key="article.id"
+          class="article-card"
+          @click="goToArticle(article.id)"
+        >
+          <h2 class="article-title">{{ article.title }}</h2>
+          <div class="article-meta">
+            <span v-if="article.source_url" class="article-host">{{ hostOf(article.source_url) }}</span>
+            <span class="article-words">{{ article.word_count.toLocaleString() }} 词</span>
+            <span class="article-time">~{{ readingMinutes(article.word_count) }} 分钟读</span>
+          </div>
+          <div class="article-footer">
+            <span class="article-age">{{ relativeTime(article.created_at) }}</span>
+            <span v-if="article.vocab_count > 0" class="article-vocab">
+              已沉淀 {{ article.vocab_count }} 个词
+            </span>
+          </div>
+        </li>
+      </ul>
+
+      <div v-if="hasMore" class="library-loadmore">
+        <button @click="loadMore" :disabled="loadingMore">
+          {{ loadingMore ? '加载中...' : '加载更多' }}
+        </button>
+      </div>
+    </main>
+
+    <!-- 添加文章模态框 -->
+    <div v-if="showModal" class="modal-overlay" @click.self="closeModal">
+      <div class="modal-box">
+        <div class="modal-header">
+          <h2>添加文章</h2>
+          <button class="modal-close" @click="closeModal">×</button>
+        </div>
+
+        <div class="modal-tabs">
+          <button
+            :class="['tab-btn', { active: importMode === 'url' }]"
+            @click="importMode = 'url'"
+          >粘贴 URL</button>
+          <button
+            :class="['tab-btn', { active: importMode === 'markdown' }]"
+            @click="importMode = 'markdown'"
+          >粘贴正文</button>
+        </div>
+
+        <!-- URL 模式 -->
+        <div v-if="importMode === 'url'" class="modal-body">
+          <label class="field-label">文章 URL</label>
+          <input
+            v-model="urlInput"
+            class="field-input"
+            type="url"
+            placeholder="https://..."
+            @keydown.enter="doImport"
+          />
+          <p v-if="importError" class="import-error">{{ importError }}</p>
+          <p v-if="fetchFailHint" class="import-hint">{{ fetchFailHint }}</p>
+        </div>
+
+        <!-- Markdown 模式 -->
+        <div v-if="importMode === 'markdown'" class="modal-body">
+          <label class="field-label">标题（必填）</label>
+          <input
+            v-model="titleInput"
+            class="field-input"
+            type="text"
+            placeholder="文章标题"
+          />
+          <label class="field-label">正文（Markdown）</label>
+          <textarea
+            v-model="markdownInput"
+            class="field-textarea"
+            placeholder="粘贴 Markdown 或纯文本正文..."
+            rows="8"
+          ></textarea>
+          <p v-if="importError" class="import-error">{{ importError }}</p>
+        </div>
+
+        <div class="modal-footer">
+          <button class="btn-cancel" @click="closeModal">取消</button>
+          <button
+            class="btn-import"
+            :disabled="importing || !canImport"
+            @click="doImport"
+          >
+            {{ importing ? '导入中...' : '导入' }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { useAuthFetch, getErrorMessage } from '@/composables/useAuthFetch'
+import { API } from '@/config'
+
+const router = useRouter()
+const { authFetchJson } = useAuthFetch()
+
+// List state
+const articles = ref([])
+const loading = ref(false)
+const loadingMore = ref(false)
+const page = ref(1)
+const PAGE_SIZE = 20
+const hasMore = ref(false)
+
+// Modal state
+const showModal = ref(false)
+const importMode = ref('url')
+const urlInput = ref('')
+const titleInput = ref('')
+const markdownInput = ref('')
+const importing = ref(false)
+const importError = ref('')
+const fetchFailHint = ref('')
+
+const canImport = computed(() => {
+  if (importMode.value === 'url') return urlInput.value.trim().length > 0
+  return titleInput.value.trim().length > 0 && markdownInput.value.trim().length > 0
+})
+
+function hostOf(url) {
+  try {
+    return new URL(url).hostname
+  } catch {
+    return url
+  }
+}
+
+function readingMinutes(wordCount) {
+  return Math.max(1, Math.round(wordCount / 200))
+}
+
+function relativeTime(iso) {
+  if (!iso) return ''
+  const diff = (Date.now() - new Date(iso).getTime()) / 1000
+  if (diff < 60) return '刚刚'
+  if (diff < 3600) return `${Math.floor(diff / 60)} 分钟前`
+  if (diff < 86400) return `${Math.floor(diff / 3600)} 小时前`
+  if (diff < 86400 * 2) return '昨天'
+  return `${Math.floor(diff / 86400)} 天前`
+}
+
+async function fetchArticles(reset = false) {
+  if (reset) {
+    loading.value = true
+    page.value = 1
+    articles.value = []
+  } else {
+    loadingMore.value = true
+  }
+  try {
+    const data = await authFetchJson(`${API.LIBRARY}/articles?page=${page.value}&page_size=${PAGE_SIZE}`)
+    const fetched = data.articles || []
+    articles.value = reset ? fetched : [...articles.value, ...fetched]
+    hasMore.value = fetched.length === PAGE_SIZE
+    page.value++
+  } catch (err) {
+    console.error('library list failed:', getErrorMessage(err, '加载失败'))
+  } finally {
+    loading.value = false
+    loadingMore.value = false
+  }
+}
+
+async function loadMore() {
+  await fetchArticles(false)
+}
+
+function goToArticle(id) {
+  router.push({ name: 'library-article', params: { id } })
+}
+
+function closeModal() {
+  showModal.value = false
+  importError.value = ''
+  fetchFailHint.value = ''
+  urlInput.value = ''
+  titleInput.value = ''
+  markdownInput.value = ''
+  importMode.value = 'url'
+}
+
+async function doImport() {
+  if (!canImport.value || importing.value) return
+  importing.value = true
+  importError.value = ''
+  fetchFailHint.value = ''
+
+  const body = {}
+  if (importMode.value === 'url') {
+    body.url = urlInput.value.trim()
+  } else {
+    body.markdown = markdownInput.value.trim()
+    body.title = titleInput.value.trim()
+  }
+
+  try {
+    const data = await authFetchJson(`${API.LIBRARY}/articles`, body)
+    closeModal()
+    if (data.existing) {
+      // Navigate directly to existing article
+      router.push({ name: 'library-article', params: { id: data.id } })
+    } else {
+      // Reload list and navigate
+      await fetchArticles(true)
+      router.push({ name: 'library-article', params: { id: data.id } })
+    }
+  } catch (err) {
+    const msg = err?.detail || err?.message || ''
+    if (typeof err?.detail === 'object' && err.detail?.error === 'fetch_failed') {
+      fetchFailHint.value = err.detail.hint || '抓取失败，请改用粘贴正文模式'
+      importMode.value = 'markdown'
+      importError.value = '该页面无法自动抓取'
+    } else {
+      importError.value = getErrorMessage(err, '导入失败，请重试')
+    }
+  } finally {
+    importing.value = false
+  }
+}
+
+onMounted(() => {
+  fetchArticles(true)
+})
+</script>
+
+<style scoped>
+.library-page {
+  min-height: 100vh;
+  background: var(--color-bg, #f5f0eb);
+  font-family: var(--font-sans, system-ui, sans-serif);
+}
+
+.library-header {
+  background: var(--color-surface, #fff);
+  border-bottom: 1px solid var(--color-border, #e8e0d8);
+  padding: 16px 24px;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.library-header-inner {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.library-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.library-title-row h1 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--color-text, #2d2320);
+  margin: 0;
+}
+
+.btn-add {
+  padding: 8px 16px;
+  background: var(--color-primary, #c8845c);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.btn-add:hover {
+  opacity: 0.9;
+}
+
+.library-main {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.library-loading,
+.library-empty {
+  text-align: center;
+  color: var(--color-text-muted, #8a7d75);
+  padding: 48px 0;
+}
+
+.article-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.article-card {
+  background: var(--color-surface, #fff);
+  border: 1px solid var(--color-border, #e8e0d8);
+  border-radius: 12px;
+  padding: 16px 20px;
+  cursor: pointer;
+  transition: box-shadow 0.15s;
+}
+
+.article-card:hover {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.article-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-text, #2d2320);
+  margin: 0 0 6px;
+  line-height: 1.4;
+}
+
+.article-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 0.82rem;
+  color: var(--color-text-muted, #8a7d75);
+  margin-bottom: 8px;
+}
+
+.article-host {
+  color: var(--color-primary, #c8845c);
+}
+
+.article-footer {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  color: var(--color-text-muted, #8a7d75);
+}
+
+.article-vocab {
+  color: var(--color-primary, #c8845c);
+}
+
+.library-loadmore {
+  text-align: center;
+  margin-top: 24px;
+}
+
+.library-loadmore button {
+  padding: 8px 24px;
+  border: 1px solid var(--color-border, #e8e0d8);
+  border-radius: 8px;
+  background: transparent;
+  cursor: pointer;
+  color: var(--color-text, #2d2320);
+}
+
+/* Modal */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  padding: 16px;
+}
+
+.modal-box {
+  background: var(--color-surface, #fff);
+  border-radius: 16px;
+  width: 100%;
+  max-width: 480px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 24px 0;
+}
+
+.modal-header h2 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 0;
+  color: var(--color-text, #2d2320);
+}
+
+.modal-close {
+  background: none;
+  border: none;
+  font-size: 1.4rem;
+  cursor: pointer;
+  color: var(--color-text-muted, #8a7d75);
+  line-height: 1;
+  padding: 4px;
+}
+
+.modal-tabs {
+  display: flex;
+  gap: 0;
+  padding: 16px 24px 0;
+  border-bottom: 1px solid var(--color-border, #e8e0d8);
+}
+
+.tab-btn {
+  padding: 8px 16px;
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: var(--color-text-muted, #8a7d75);
+  font-size: 0.9rem;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+}
+
+.tab-btn.active {
+  color: var(--color-primary, #c8845c);
+  border-bottom-color: var(--color-primary, #c8845c);
+  font-weight: 500;
+}
+
+.modal-body {
+  padding: 20px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.field-label {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--color-text, #2d2320);
+}
+
+.field-input,
+.field-textarea {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--color-border, #e8e0d8);
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-family: inherit;
+  box-sizing: border-box;
+  background: var(--color-bg, #f5f0eb);
+  color: var(--color-text, #2d2320);
+}
+
+.field-textarea {
+  resize: vertical;
+  min-height: 120px;
+}
+
+.import-error {
+  color: #d44;
+  font-size: 0.85rem;
+  margin: 0;
+}
+
+.import-hint {
+  color: var(--color-primary, #c8845c);
+  font-size: 0.85rem;
+  margin: 0;
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 0 24px 20px;
+}
+
+.btn-cancel {
+  padding: 9px 18px;
+  border: 1px solid var(--color-border, #e8e0d8);
+  border-radius: 8px;
+  background: transparent;
+  cursor: pointer;
+  color: var(--color-text, #2d2320);
+  font-size: 0.9rem;
+}
+
+.btn-import {
+  padding: 9px 18px;
+  background: var(--color-primary, #c8845c);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.btn-import:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+</style>

--- a/frontend/src/views/LibraryArticle.vue
+++ b/frontend/src/views/LibraryArticle.vue
@@ -1,0 +1,868 @@
+<template>
+  <div class="article-page">
+    <!-- Top bar -->
+    <header class="article-topbar">
+      <button class="back-btn" @click="goBack">← 返回</button>
+      <h1 class="article-topbar-title">{{ article?.title || '加载中...' }}</h1>
+      <button v-if="article" class="delete-btn" @click="confirmDelete">删除</button>
+    </header>
+
+    <div v-if="loading" class="article-loading">加载中...</div>
+    <div v-else-if="!article" class="article-error">文章不存在或已删除</div>
+
+    <div v-else class="article-layout">
+      <!-- Main reading area -->
+      <main class="article-content" ref="contentRef" @mouseup="onMouseUp">
+        <div class="markdown-body" v-html="renderedMarkdown"></div>
+
+        <!-- Floating bubble for word click / selection -->
+        <div
+          v-if="bubble.visible"
+          class="float-bubble"
+          :style="{ top: bubble.top + 'px', left: bubble.left + 'px' }"
+        >
+          <!-- Word click bubble: show IPA + expand button -->
+          <template v-if="bubble.mode === 'word'">
+            <span class="bubble-ipa">{{ bubble.ipa || '...' }}</span>
+            <button class="bubble-btn" @click="expandExplain(bubble.text, 'word')">展开解读</button>
+          </template>
+          <!-- Selection bubble: translate button -->
+          <template v-else-if="bubble.mode === 'selection'">
+            <button class="bubble-btn" @click="expandExplain(bubble.text, 'sentence')">翻译</button>
+          </template>
+        </div>
+      </main>
+
+      <!-- Right sidebar: 本文沉淀 -->
+      <aside :class="['article-sidebar', { open: sidebarOpen }]">
+        <button class="sidebar-toggle" @click="sidebarOpen = !sidebarOpen">
+          本文沉淀 ({{ vocabItems.length }})
+        </button>
+        <div class="sidebar-body">
+          <div v-if="vocabLoading" class="sidebar-loading">加载中...</div>
+          <div v-else-if="vocabItems.length === 0" class="sidebar-empty">暂无沉淀语言点</div>
+          <ul v-else class="vocab-list">
+            <li
+              v-for="item in vocabItems"
+              :key="item.id"
+              :class="['vocab-item', { expanded: expandedVocabId === item.id }]"
+            >
+              <div class="vocab-head" @click="toggleVocab(item)">
+                <span class="vocab-text">{{ truncate(item.source_text, 50) }}</span>
+                <span :class="['vocab-badge', item.explanation_json ? 'ready' : 'pending']">
+                  {{ item.explanation_json ? 'ready' : 'pending' }}
+                </span>
+              </div>
+              <div v-if="expandedVocabId === item.id" class="vocab-detail">
+                <template v-if="parsedExp(item)">
+                  <div v-if="parsedExp(item).phonetic" class="exp-row">
+                    <strong>/{{ parsedExp(item).phonetic }}/</strong>
+                  </div>
+                  <div v-if="parsedExp(item).meaning" class="exp-row">{{ parsedExp(item).meaning }}</div>
+                  <div v-if="parsedExp(item).grammar" class="exp-row exp-minor">{{ parsedExp(item).grammar }}</div>
+                  <div v-if="parsedExp(item).definitions?.length" class="exp-row">
+                    <ul><li v-for="d in parsedExp(item).definitions" :key="d">{{ d }}</li></ul>
+                  </div>
+                  <div v-if="parsedExp(item).examples?.length" class="exp-row">
+                    <ul><li v-for="e in parsedExp(item).examples" :key="e">{{ e }}</li></ul>
+                  </div>
+                </template>
+                <template v-else>
+                  <button
+                    class="exp-fetch-btn"
+                    :disabled="item._fetching"
+                    @click="fetchPending(item)"
+                  >
+                    {{ item._fetching ? '生成中...' : '点击生成解读' }}
+                  </button>
+                  <p v-if="item._fetchError" class="exp-error">{{ item._fetchError }}</p>
+                </template>
+              </div>
+            </li>
+          </ul>
+        </div>
+      </aside>
+    </div>
+
+    <!-- Explanation detail modal/overlay (for expanded explain) -->
+    <div v-if="explainModal.visible" class="explain-overlay" @click.self="explainModal.visible = false">
+      <div class="explain-box">
+        <div class="explain-header">
+          <strong>{{ explainModal.text }}</strong>
+          <button @click="explainModal.visible = false">×</button>
+        </div>
+        <div v-if="explainModal.loading" class="explain-loading">解读中...</div>
+        <div v-else-if="explainModal.error" class="explain-error">{{ explainModal.error }}</div>
+        <div v-else class="explain-body">
+          <div v-if="explainModal.data?.phonetic" class="exp-row">
+            <strong>/{{ explainModal.data.phonetic }}/</strong>
+          </div>
+          <div v-if="explainModal.data?.meaning" class="exp-row">{{ explainModal.data.meaning }}</div>
+          <div v-if="explainModal.data?.grammar" class="exp-row exp-minor">{{ explainModal.data.grammar }}</div>
+          <div v-if="explainModal.data?.definitions?.length" class="exp-row">
+            <ul><li v-for="d in explainModal.data.definitions" :key="d">{{ d }}</li></ul>
+          </div>
+          <div v-if="explainModal.data?.examples?.length" class="exp-row">
+            <ul><li v-for="e in explainModal.data.examples" :key="e">{{ e }}</li></ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, onUnmounted, nextTick } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
+import { useAuthFetch, getErrorMessage } from '@/composables/useAuthFetch'
+import { API } from '@/config'
+
+const router = useRouter()
+const route = useRoute()
+const { authFetch, authFetchJson } = useAuthFetch()
+
+const articleId = computed(() => Number(route.params.id))
+
+// Article state
+const article = ref(null)
+const loading = ref(true)
+
+// Sidebar state
+const sidebarOpen = ref(true)
+const vocabItems = ref([])
+const vocabLoading = ref(false)
+const expandedVocabId = ref(null)
+
+// Floating bubble state
+const contentRef = ref(null)
+const bubble = ref({ visible: false, top: 0, left: 0, text: '', ipa: '', mode: 'word' })
+
+// Explain modal state
+const explainModal = ref({ visible: false, text: '', loading: false, error: '', data: null })
+
+// ── Markdown renderer (simple, no external deps) ──────────
+
+function escapeHtml(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+function renderMarkdown(md) {
+  if (!md) return ''
+  const lines = md.split('\n')
+  const result = []
+  let inCode = false
+  let codeLang = ''
+  let codeLines = []
+  let inList = false
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+
+    // Code block
+    if (line.startsWith('```')) {
+      if (!inCode) {
+        inCode = true
+        codeLang = line.slice(3).trim()
+        codeLines = []
+        if (inList) { result.push('</ul>'); inList = false }
+      } else {
+        inCode = false
+        const escaped = codeLines.map(escapeHtml).join('\n')
+        result.push(`<pre><code${codeLang ? ` class="language-${escapeHtml(codeLang)}"` : ''}>${escaped}</code></pre>`)
+        codeLines = []
+        codeLang = ''
+      }
+      continue
+    }
+
+    if (inCode) {
+      codeLines.push(line)
+      continue
+    }
+
+    // Headings
+    const hMatch = line.match(/^(#{1,6})\s+(.+)$/)
+    if (hMatch) {
+      if (inList) { result.push('</ul>'); inList = false }
+      const level = hMatch[1].length
+      result.push(`<h${level}>${inlineFormat(hMatch[2])}</h${level}>`)
+      continue
+    }
+
+    // Horizontal rule
+    if (/^---+$/.test(line.trim()) || /^\*\*\*+$/.test(line.trim())) {
+      if (inList) { result.push('</ul>'); inList = false }
+      result.push('<hr>')
+      continue
+    }
+
+    // Unordered list
+    const liMatch = line.match(/^[\s]*[-*+]\s+(.+)$/)
+    if (liMatch) {
+      if (!inList) { result.push('<ul>'); inList = true }
+      result.push(`<li>${inlineFormat(liMatch[1])}</li>`)
+      continue
+    }
+
+    // Close list if needed
+    if (inList && line.trim() === '') {
+      result.push('</ul>')
+      inList = false
+    }
+
+    // Blank line = paragraph break
+    if (line.trim() === '') {
+      result.push('<br>')
+      continue
+    }
+
+    // Paragraph
+    if (inList) { result.push('</ul>'); inList = false }
+    result.push(`<p>${inlineFormat(line)}</p>`)
+  }
+
+  if (inList) result.push('</ul>')
+  if (inCode && codeLines.length) {
+    result.push(`<pre><code>${codeLines.map(escapeHtml).join('\n')}</code></pre>`)
+  }
+
+  return result.join('')
+}
+
+function inlineFormat(text) {
+  // Bold **...**
+  text = text.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+  // Italic *...*
+  text = text.replace(/\*(.+?)\*/g, '<em>$1</em>')
+  // Inline code `...`
+  text = text.replace(/`([^`]+)`/g, '<code>$1</code>')
+  // Links [text](url)
+  text = text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>')
+  return text
+}
+
+const renderedMarkdown = computed(() => {
+  if (!article.value?.markdown) return ''
+  return renderMarkdown(article.value.markdown)
+})
+
+// ── Data loading ───────────────────────────────────────────
+
+async function loadArticle() {
+  loading.value = true
+  try {
+    article.value = await authFetchJson(`${API.LIBRARY}/articles/${articleId.value}`)
+  } catch (err) {
+    article.value = null
+  } finally {
+    loading.value = false
+  }
+}
+
+async function loadVocab() {
+  vocabLoading.value = true
+  try {
+    const resp = await authFetch(
+      `${API.VOCAB}?source_type=library&source_ref=${articleId.value}&limit=200`
+    )
+    if (!resp.ok) throw new Error('load failed')
+    const data = await resp.json()
+    vocabItems.value = (data.items || []).map(it => ({ ...it, _fetching: false, _fetchError: '' }))
+  } catch (err) {
+    console.error('vocab load failed:', err)
+  } finally {
+    vocabLoading.value = false
+  }
+}
+
+// ── Navigation ─────────────────────────────────────────────
+
+function goBack() {
+  router.push({ name: 'library' })
+}
+
+async function confirmDelete() {
+  if (!confirm('确定删除这篇文章？（已沉淀的生词不受影响）')) return
+  try {
+    await authFetchJson(`${API.LIBRARY}/articles/${articleId.value}`, null, { method: 'DELETE' })
+    router.push({ name: 'library' })
+  } catch (err) {
+    alert(getErrorMessage(err, '删除失败'))
+  }
+}
+
+// ── Word click / selection interaction ─────────────────────
+
+function isInsideCode(node) {
+  let el = node
+  while (el) {
+    if (el.tagName === 'PRE' || el.tagName === 'CODE') return true
+    el = el.parentElement
+  }
+  return false
+}
+
+function getWordAtPoint(x, y) {
+  const range = document.caretRangeFromPoint ? document.caretRangeFromPoint(x, y) : null
+  if (!range || !range.startContainer || range.startContainer.nodeType !== Node.TEXT_NODE) return null
+  if (isInsideCode(range.startContainer)) return null
+
+  const text = range.startContainer.textContent || ''
+  const offset = range.startOffset
+
+  // Expand left and right to word boundaries
+  let start = offset
+  let end = offset
+  while (start > 0 && /\w/.test(text[start - 1])) start--
+  while (end < text.length && /\w/.test(text[end])) end++
+  const word = text.slice(start, end).trim()
+  return word || null
+}
+
+async function onMouseUp(e) {
+  await nextTick()
+  const selection = window.getSelection()
+  const selectedText = selection ? selection.toString().trim() : ''
+
+  if (selectedText.length >= 2) {
+    // Selection mode
+    const range = selection.getRangeAt(0)
+    const rect = range.getBoundingClientRect()
+    const containerRect = contentRef.value.getBoundingClientRect()
+    bubble.value = {
+      visible: true,
+      top: rect.top - containerRect.top - 44,
+      left: Math.max(0, rect.left - containerRect.left),
+      text: selectedText,
+      ipa: '',
+      mode: 'selection',
+    }
+    return
+  }
+
+  // Word click
+  const word = getWordAtPoint(e.clientX, e.clientY)
+  if (!word) {
+    bubble.value.visible = false
+    return
+  }
+
+  const containerRect = contentRef.value.getBoundingClientRect()
+  bubble.value = {
+    visible: true,
+    top: e.clientY - containerRect.top - 44,
+    left: Math.max(0, e.clientX - containerRect.left - 40),
+    text: word,
+    ipa: '...',
+    mode: 'word',
+  }
+
+  // Fetch IPA
+  try {
+    const data = await authFetchJson(
+      `${API.LIBRARY}/articles/${articleId.value}/explain/phonetic`,
+      { text: word, item_type: 'word' },
+    )
+    if (bubble.value.text === word) {
+      bubble.value.ipa = data.phonetic || ''
+    }
+  } catch (err) {
+    if (bubble.value.text === word) bubble.value.ipa = ''
+  }
+}
+
+function closeBubble() {
+  bubble.value.visible = false
+}
+
+async function expandExplain(text, kind) {
+  closeBubble()
+  explainModal.value = { visible: true, text, loading: true, error: '', data: null }
+
+  try {
+    const result = await authFetchJson(
+      `${API.LIBRARY}/articles/${articleId.value}/explain`,
+      { text, kind },
+    )
+    explainModal.value.data = result.explanation || null
+    explainModal.value.loading = false
+    // Refresh vocab sidebar
+    loadVocab()
+  } catch (err) {
+    explainModal.value.error = getErrorMessage(err, '解读失败，请重试')
+    explainModal.value.loading = false
+  }
+}
+
+// ── Vocab sidebar ──────────────────────────────────────────
+
+function truncate(text, n) {
+  if (!text) return ''
+  return text.length > n ? text.slice(0, n) + '…' : text
+}
+
+function parsedExp(item) {
+  if (!item.explanation_json) return null
+  try {
+    return JSON.parse(item.explanation_json)
+  } catch {
+    return null
+  }
+}
+
+function toggleVocab(item) {
+  expandedVocabId.value = expandedVocabId.value === item.id ? null : item.id
+}
+
+async function fetchPending(item) {
+  item._fetching = true
+  item._fetchError = ''
+  try {
+    const result = await authFetchJson(
+      `${API.LIBRARY}/articles/${articleId.value}/explain`,
+      { text: item.source_text, kind: item.item_type === 'sentence' ? 'sentence' : 'word' },
+    )
+    const idx = vocabItems.value.findIndex(v => v.id === item.id)
+    if (idx !== -1) {
+      vocabItems.value[idx] = {
+        ...vocabItems.value[idx],
+        explanation_json: JSON.stringify(result.explanation || {}),
+        _fetching: false,
+        _fetchError: '',
+      }
+    }
+  } catch (err) {
+    item._fetching = false
+    item._fetchError = getErrorMessage(err, '生成失败，请稍后重试')
+  }
+}
+
+// ── Click outside to close bubble ─────────────────────────
+
+function onDocClick(e) {
+  if (bubble.value.visible) {
+    const floatEl = document.querySelector('.float-bubble')
+    if (floatEl && !floatEl.contains(e.target)) {
+      bubble.value.visible = false
+    }
+  }
+}
+
+onMounted(async () => {
+  await loadArticle()
+  loadVocab()
+  document.addEventListener('click', onDocClick, true)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('click', onDocClick, true)
+})
+</script>
+
+<style scoped>
+.article-page {
+  min-height: 100vh;
+  background: var(--color-bg, #f5f0eb);
+  font-family: var(--font-sans, system-ui, sans-serif);
+}
+
+/* Top bar */
+.article-topbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 24px;
+  background: var(--color-surface, #fff);
+  border-bottom: 1px solid var(--color-border, #e8e0d8);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.back-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-primary, #c8845c);
+  font-size: 0.9rem;
+  white-space: nowrap;
+  padding: 4px 8px;
+}
+
+.article-topbar-title {
+  flex: 1;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-text, #2d2320);
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.delete-btn {
+  background: none;
+  border: 1px solid #d44;
+  color: #d44;
+  border-radius: 6px;
+  padding: 5px 12px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+/* Layout */
+.article-loading,
+.article-error {
+  text-align: center;
+  color: var(--color-text-muted, #8a7d75);
+  padding: 48px;
+}
+
+.article-layout {
+  display: flex;
+  gap: 24px;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 24px;
+  align-items: flex-start;
+  position: relative;
+}
+
+/* Main content */
+.article-content {
+  flex: 1;
+  min-width: 0;
+  max-width: 720px;
+  background: var(--color-surface, #fff);
+  border-radius: 12px;
+  padding: 32px;
+  position: relative;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+}
+
+/* Markdown styles */
+.markdown-body :deep(h1),
+.markdown-body :deep(h2),
+.markdown-body :deep(h3),
+.markdown-body :deep(h4) {
+  color: var(--color-text, #2d2320);
+  margin: 1.2em 0 0.5em;
+  line-height: 1.3;
+}
+
+.markdown-body :deep(h1) { font-size: 1.5rem; }
+.markdown-body :deep(h2) { font-size: 1.25rem; }
+.markdown-body :deep(h3) { font-size: 1.1rem; }
+
+.markdown-body :deep(p) {
+  margin: 0.7em 0;
+  line-height: 1.7;
+  color: var(--color-text, #2d2320);
+}
+
+.markdown-body :deep(ul),
+.markdown-body :deep(ol) {
+  padding-left: 1.5em;
+  margin: 0.5em 0;
+}
+
+.markdown-body :deep(li) {
+  margin: 0.3em 0;
+  line-height: 1.6;
+}
+
+.markdown-body :deep(pre) {
+  background: #f4f4f4;
+  border-radius: 6px;
+  padding: 12px 16px;
+  overflow-x: auto;
+  margin: 1em 0;
+  user-select: text;
+}
+
+.markdown-body :deep(code) {
+  font-family: 'Fira Code', 'Consolas', monospace;
+  font-size: 0.88em;
+  background: rgba(0, 0, 0, 0.06);
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+
+.markdown-body :deep(pre code) {
+  background: none;
+  padding: 0;
+}
+
+.markdown-body :deep(a) {
+  color: var(--color-primary, #c8845c);
+  text-decoration: none;
+}
+
+.markdown-body :deep(hr) {
+  border: none;
+  border-top: 1px solid var(--color-border, #e8e0d8);
+  margin: 1.5em 0;
+}
+
+/* Floating bubble */
+.float-bubble {
+  position: absolute;
+  background: #2d2320;
+  color: #fff;
+  border-radius: 8px;
+  padding: 6px 12px;
+  font-size: 0.85rem;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  z-index: 50;
+  box-shadow: 0 3px 12px rgba(0, 0, 0, 0.25);
+  white-space: nowrap;
+  pointer-events: auto;
+}
+
+.bubble-ipa {
+  font-style: italic;
+  opacity: 0.85;
+}
+
+.bubble-btn {
+  background: var(--color-primary, #c8845c);
+  border: none;
+  color: #fff;
+  border-radius: 5px;
+  padding: 3px 10px;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+/* Sidebar */
+.article-sidebar {
+  width: 280px;
+  flex-shrink: 0;
+  background: var(--color-surface, #fff);
+  border-radius: 12px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+  overflow: hidden;
+}
+
+.sidebar-toggle {
+  width: 100%;
+  padding: 14px 16px;
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--color-border, #e8e0d8);
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-text, #2d2320);
+  cursor: pointer;
+  text-align: left;
+}
+
+.sidebar-body {
+  padding: 8px 0;
+  max-height: calc(100vh - 140px);
+  overflow-y: auto;
+}
+
+.sidebar-loading,
+.sidebar-empty {
+  padding: 16px;
+  color: var(--color-text-muted, #8a7d75);
+  font-size: 0.85rem;
+  text-align: center;
+}
+
+.vocab-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.vocab-item {
+  border-bottom: 1px solid var(--color-border, #e8e0d8);
+}
+
+.vocab-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  cursor: pointer;
+  gap: 8px;
+}
+
+.vocab-head:hover {
+  background: var(--color-bg, #f5f0eb);
+}
+
+.vocab-text {
+  font-size: 0.88rem;
+  color: var(--color-text, #2d2320);
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.vocab-badge {
+  font-size: 0.72rem;
+  border-radius: 4px;
+  padding: 1px 5px;
+  font-weight: 500;
+  flex-shrink: 0;
+}
+
+.vocab-badge.ready {
+  background: #e6f4e6;
+  color: #2a6e2a;
+}
+
+.vocab-badge.pending {
+  background: #fff3e0;
+  color: #9a6000;
+}
+
+.vocab-detail {
+  padding: 8px 16px 12px;
+  background: var(--color-bg, #f5f0eb);
+  border-top: 1px solid var(--color-border, #e8e0d8);
+}
+
+.exp-row {
+  font-size: 0.85rem;
+  color: var(--color-text, #2d2320);
+  margin: 4px 0;
+  line-height: 1.5;
+}
+
+.exp-minor {
+  color: var(--color-text-muted, #8a7d75);
+}
+
+.exp-row ul {
+  margin: 4px 0;
+  padding-left: 1.2em;
+}
+
+.exp-row li {
+  margin: 2px 0;
+}
+
+.exp-fetch-btn {
+  padding: 6px 12px;
+  background: var(--color-primary, #c8845c);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.82rem;
+  cursor: pointer;
+}
+
+.exp-fetch-btn:disabled {
+  opacity: 0.6;
+}
+
+.exp-error {
+  color: #d44;
+  font-size: 0.8rem;
+  margin: 4px 0 0;
+}
+
+/* Explain modal */
+.explain-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  z-index: 200;
+  padding: 0;
+}
+
+@media (min-width: 640px) {
+  .explain-overlay {
+    align-items: center;
+  }
+}
+
+.explain-box {
+  background: var(--color-surface, #fff);
+  border-radius: 16px 16px 0 0;
+  width: 100%;
+  max-width: 540px;
+  max-height: 80vh;
+  overflow-y: auto;
+  padding: 20px 24px 32px;
+}
+
+@media (min-width: 640px) {
+  .explain-box {
+    border-radius: 16px;
+    max-height: 60vh;
+  }
+}
+
+.explain-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.explain-header strong {
+  font-size: 1.05rem;
+}
+
+.explain-header button {
+  background: none;
+  border: none;
+  font-size: 1.3rem;
+  cursor: pointer;
+  color: var(--color-text-muted, #8a7d75);
+}
+
+.explain-loading,
+.explain-error {
+  padding: 16px 0;
+  color: var(--color-text-muted, #8a7d75);
+  font-size: 0.9rem;
+}
+
+.explain-error {
+  color: #d44;
+}
+
+.explain-body .exp-row {
+  margin: 6px 0;
+}
+
+/* Responsive */
+@media (max-width: 1280px) {
+  .article-sidebar {
+    width: 240px;
+  }
+}
+
+@media (max-width: 900px) {
+  .article-layout {
+    flex-direction: column;
+    padding: 16px;
+  }
+
+  .article-sidebar {
+    width: 100%;
+  }
+
+  .article-content {
+    max-width: 100%;
+  }
+}
+</style>

--- a/main.py
+++ b/main.py
@@ -21,6 +21,7 @@ from app.routers.bbc_review import router as bbc_review_router
 from app.routers.vocab import router as vocab_router
 from app.routers.polish import router as polish_router
 from app.routers.model import router as model_router
+from app.routers.library import router as library_router
 
 
 # ── V0.8 前端重构挂载策略（Pass 3 plan §4 + Critic B1-B5）────────────
@@ -49,12 +50,13 @@ API_PREFIXES = (
     "translate/",
     "vocab/",
     "polish/",
+    "library/",
     "auth/",
     "ask/",
     "assessment/",
     "settings/",
     "stats/",
-    "bbc-eaw/",
+    # "bbc-eaw/" 已迁移到 articles/episodes/*，articles/ 前缀已覆盖
     "health",
     "debug/",
     "legacy/",
@@ -100,6 +102,7 @@ app.include_router(bbc_review_router)
 app.include_router(vocab_router)
 app.include_router(polish_router)
 app.include_router(model_router)
+app.include_router(library_router)
 
 # 数据目录挂载（audio_cache、tts_cache 等）——无论新旧前端都要读
 app.mount("/static", StaticFiles(directory="static"), name="static")

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ yt-dlp>=2024.0.0
 bcrypt==4.2.0
 PyJWT==2.9.0
 eng-to-ipa==0.0.2
+trafilatura>=2.0.0

--- a/tests/test_v08_library.py
+++ b/tests/test_v08_library.py
@@ -1,0 +1,367 @@
+"""Library module tests — V0.8
+
+Tests cover:
+  - test_import_article_markdown: paste mode creates article
+  - test_import_article_url_dedup: same URL twice returns existing
+  - test_list_articles: pagination, only active
+  - test_delete_article_soft: soft delete, vocab not affected
+  - test_explain_creates_vocab: explain endpoint auto-saves to vocab with source_type='library'
+"""
+import json
+import pytest
+from unittest.mock import patch, MagicMock
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session as OrmSession
+
+from main import app
+from app.models.db import engine, LibraryArticle, Vocabulary, init_db
+from app.routers.auth import get_current_user_id, get_current_user_id_optional
+
+USER = "test_user_v08_library_task1"
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _override_user():
+    app.dependency_overrides[get_current_user_id] = lambda: USER
+    app.dependency_overrides[get_current_user_id_optional] = lambda: USER
+    yield
+    app.dependency_overrides.pop(get_current_user_id, None)
+    app.dependency_overrides.pop(get_current_user_id_optional, None)
+
+
+@pytest.fixture(autouse=True)
+def _cleanup():
+    init_db()
+    with OrmSession(engine) as s:
+        s.query(LibraryArticle).filter(
+            LibraryArticle.user_id.like("test_user_v08_library_%")
+        ).delete()
+        s.query(Vocabulary).filter(
+            Vocabulary.user_id.like("test_user_v08_library_%")
+        ).delete()
+        s.commit()
+    yield
+    with OrmSession(engine) as s:
+        s.query(LibraryArticle).filter(
+            LibraryArticle.user_id.like("test_user_v08_library_%")
+        ).delete()
+        s.query(Vocabulary).filter(
+            Vocabulary.user_id.like("test_user_v08_library_%")
+        ).delete()
+        s.commit()
+
+
+@pytest.fixture
+def stub_explain(monkeypatch):
+    """Stub out LLM calls to avoid real API requests."""
+    from app.services import explain_service
+    import app.routers.library as lr
+
+    async def _fake(text, kind, user_id, context="", force=False):
+        return {
+            "explanation": {"meaning": "stub-" + text, "phonetic": "stʌb"},
+            "cefr_level": "B1",
+            "cached": False,
+        }
+
+    monkeypatch.setattr(explain_service, "explain_text", _fake)
+    monkeypatch.setattr(lr, "explain_text", _fake)
+
+
+# ── Tests ──────────────────────────────────────────────────
+
+def test_import_article_markdown():
+    """Paste mode: creates article with correct fields."""
+    resp = client.post(
+        "/library/articles",
+        json={
+            "markdown": "# Hello World\n\nThis is a test article with some words.",
+            "title": "Hello World",
+        },
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["title"] == "Hello World"
+    assert data["status"] == "active"
+    assert data["word_count"] > 0
+    assert data["source_url"] is None
+    assert data["existing"] is False
+
+
+def test_import_article_markdown_title_from_heading():
+    """Paste mode: title extracted from first # heading when not provided."""
+    resp = client.post(
+        "/library/articles",
+        json={
+            "markdown": "# Extracted Title\n\nContent here.",
+        },
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["title"] == "Extracted Title"
+
+
+def test_import_article_url_dedup():
+    """Same URL imported twice returns existing article with existing=True."""
+    # First import using mock trafilatura
+    fake_md = "# Spec Driven Development\n\nSome content about spec driven development."
+    fake_meta = {"title": "Spec Driven Development", "site_name": "example.com", "author": None}
+
+    with patch("app.services.library_service._extract_from_url") as mock_extract:
+        mock_extract.return_value = (fake_md, fake_meta)
+        resp1 = client.post(
+            "/library/articles",
+            json={"url": "https://example.com/spec-driven"},
+        )
+
+    assert resp1.status_code == 201
+    data1 = resp1.json()
+    assert data1["existing"] is False
+    article_id = data1["id"]
+
+    # Second import of same URL
+    with patch("app.services.library_service._extract_from_url") as mock_extract:
+        mock_extract.return_value = (fake_md, fake_meta)
+        resp2 = client.post(
+            "/library/articles",
+            json={"url": "https://example.com/spec-driven"},
+        )
+
+    assert resp2.status_code == 200
+    data2 = resp2.json()
+    assert data2["existing"] is True
+    assert data2["id"] == article_id
+
+
+def test_import_article_url_fetch_failed():
+    """Fetch failure returns 400 with fetch_failed error."""
+    with patch("app.services.library_service._extract_from_url") as mock_extract:
+        mock_extract.side_effect = ValueError("fetch_failed")
+        resp = client.post(
+            "/library/articles",
+            json={"url": "https://example.com/fail"},
+        )
+
+    assert resp.status_code == 400
+    data = resp.json()
+    assert data["detail"]["error"] == "fetch_failed"
+    assert "粘贴正文模式" in data["detail"]["hint"]
+
+
+def test_list_articles():
+    """List returns only active articles with pagination."""
+    # Insert 3 articles
+    ids = []
+    for i in range(3):
+        resp = client.post(
+            "/library/articles",
+            json={
+                "markdown": f"# Article {i}\n\nContent {i}.",
+                "title": f"Article {i}",
+            },
+        )
+        assert resp.status_code == 201
+        ids.append(resp.json()["id"])
+
+    # All articles are listed
+    resp = client.get("/library/articles?page=1&page_size=10")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["page"] == 1
+    assert data["page_size"] == 10
+    assert len(data["articles"]) == 3
+
+    # Pagination works
+    resp = client.get("/library/articles?page=1&page_size=2")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["articles"]) == 2
+
+    resp2 = client.get("/library/articles?page=2&page_size=2")
+    assert resp2.status_code == 200
+    data2 = resp2.json()
+    assert len(data2["articles"]) == 1
+
+    # All returned articles belong to current user
+    all_ids = [a["id"] for a in data["articles"]] + [a["id"] for a in data2["articles"]]
+    for aid in ids:
+        assert aid in all_ids
+
+
+def test_list_excludes_deleted():
+    """Deleted articles do not appear in list."""
+    resp = client.post(
+        "/library/articles",
+        json={"markdown": "# Deleted Article\n\nContent.", "title": "Deleted Article"},
+    )
+    assert resp.status_code == 201
+    article_id = resp.json()["id"]
+
+    # Delete it
+    del_resp = client.delete(f"/library/articles/{article_id}")
+    assert del_resp.status_code == 200
+
+    # List should be empty
+    list_resp = client.get("/library/articles")
+    assert list_resp.status_code == 200
+    assert len(list_resp.json()["articles"]) == 0
+
+
+def test_delete_article_soft():
+    """Soft delete: article disappears from list but vocab remains."""
+    # Create article
+    resp = client.post(
+        "/library/articles",
+        json={"markdown": "# Test\n\nSome words here.", "title": "Test"},
+    )
+    assert resp.status_code == 201
+    article_id = resp.json()["id"]
+
+    # Manually add a vocab item tied to this article
+    from app.services import vocab_service
+    vocab_service.save_item(
+        user_id=USER,
+        source_text="some words",
+        translated_text="一些词",
+        direction="en2zh",
+        item_type="phrase",
+        source_type="library",
+        source_ref=str(article_id),
+    )
+
+    # Soft delete article
+    del_resp = client.delete(f"/library/articles/{article_id}")
+    assert del_resp.status_code == 200
+    assert del_resp.json()["deleted"] is True
+
+    # Article gone from list
+    list_resp = client.get("/library/articles")
+    assert list_resp.status_code == 200
+    articles = list_resp.json()["articles"]
+    ids = [a["id"] for a in articles]
+    assert article_id not in ids
+
+    # Vocab still exists (not cascade deleted)
+    from app.services import vocab_service as vs
+    items = vs.list_items(user_id=USER, source_type="library", source_ref=str(article_id))
+    assert len(items) == 1
+    assert items[0]["source_text"] == "some words"
+
+
+def test_get_article_detail():
+    """GET /library/articles/{id} returns full markdown."""
+    resp = client.post(
+        "/library/articles",
+        json={"markdown": "# Detail Test\n\nFull content here.", "title": "Detail Test"},
+    )
+    assert resp.status_code == 201
+    article_id = resp.json()["id"]
+
+    get_resp = client.get(f"/library/articles/{article_id}")
+    assert get_resp.status_code == 200
+    data = get_resp.json()
+    assert data["id"] == article_id
+    assert "Full content here" in data["markdown"]
+
+
+def test_get_article_not_found():
+    """GET on non-existent article returns 404."""
+    resp = client.get("/library/articles/999999")
+    assert resp.status_code == 404
+
+
+def test_explain_creates_vocab(stub_explain):
+    """explain endpoint auto-saves to vocab with source_type='library'."""
+    # Create article
+    resp = client.post(
+        "/library/articles",
+        json={"markdown": "# Explain Test\n\nSome content.", "title": "Explain Test"},
+    )
+    assert resp.status_code == 201
+    article_id = resp.json()["id"]
+
+    # Call explain
+    explain_resp = client.post(
+        f"/library/articles/{article_id}/explain",
+        json={"text": "spec-driven", "kind": "word"},
+    )
+    assert explain_resp.status_code == 200
+
+    # Check vocab was created
+    from app.services import vocab_service as vs
+    items = vs.list_items(user_id=USER, source_type="library", source_ref=str(article_id))
+    assert len(items) == 1
+    item = items[0]
+    assert item["source_text"] == "spec-driven"
+    assert item["source_type"] == "library"
+    assert item["source_ref"] == str(article_id)
+    # explanation_json should be backfilled
+    assert item["explanation_json"] is not None
+    parsed = json.loads(item["explanation_json"])
+    assert parsed["meaning"] == "stub-spec-driven"
+
+
+def test_phonetic_creates_vocab():
+    """phonetic endpoint saves placeholder to vocab."""
+    resp = client.post(
+        "/library/articles",
+        json={"markdown": "# IPA Test\n\nContent.", "title": "IPA Test"},
+    )
+    assert resp.status_code == 201
+    article_id = resp.json()["id"]
+
+    phonetic_resp = client.post(
+        f"/library/articles/{article_id}/explain/phonetic",
+        json={"text": "development"},
+    )
+    assert phonetic_resp.status_code == 200
+
+    # Vocab placeholder should exist
+    from app.services import vocab_service as vs
+    items = vs.list_items(user_id=USER, source_type="library", source_ref=str(article_id))
+    assert len(items) == 1
+    assert items[0]["source_text"] == "development"
+    assert items[0]["source_type"] == "library"
+
+
+def test_refetch_paste_mode_returns_400():
+    """Refetch on paste-mode article (no URL) returns 400."""
+    resp = client.post(
+        "/library/articles",
+        json={"markdown": "# Paste\n\nContent.", "title": "Paste"},
+    )
+    assert resp.status_code == 201
+    article_id = resp.json()["id"]
+
+    refetch_resp = client.post(f"/library/articles/{article_id}/refetch")
+    assert refetch_resp.status_code == 400
+
+
+def test_vocab_count_in_list():
+    """Article list includes vocab_count per article."""
+    resp = client.post(
+        "/library/articles",
+        json={"markdown": "# VocabCount\n\nWords.", "title": "VocabCount"},
+    )
+    assert resp.status_code == 201
+    article_id = resp.json()["id"]
+
+    # Add 2 vocab items
+    from app.services import vocab_service as vs
+    vs.save_item(
+        user_id=USER, source_text="word1", translated_text="词1",
+        direction="en2zh", item_type="word", source_type="library",
+        source_ref=str(article_id),
+    )
+    vs.save_item(
+        user_id=USER, source_text="word2", translated_text="词2",
+        direction="en2zh", item_type="word", source_type="library",
+        source_ref=str(article_id),
+    )
+
+    list_resp = client.get("/library/articles")
+    assert list_resp.status_code == 200
+    articles = list_resp.json()["articles"]
+    assert len(articles) == 1
+    assert articles[0]["vocab_count"] == 2


### PR DESCRIPTION
## Summary

- **后端**：新增 `library_articles` 表（`LibraryArticle` ORM model）+ `library_service.py`（trafilatura URL 抓取 + 粘贴 Markdown 导入 + CRUD）+ `app/routers/library.py`（7 个端点：CRUD + 3 个解读端点）；添加 `trafilatura>=2.0.0` 依赖；`VALID_SOURCE_TYPES` 加入 `"library"`
- **前端**：新增 `Library.vue`（列表页 + 添加文章模态框）+ `LibraryArticle.vue`（阅读详情 + 点词浮气泡 + 选区翻译 + 本文沉淀侧栏）；路由 `/library` + `/library/:id`；Home 页导航加入「文章库」入口
- **测试**：13 个测试全绿，覆盖粘贴导入、URL 去重、分页、软删、explain 自动入库 vocabulary、phonetic、vocab_count

## Key Design Decisions

- URL 去重：(user_id, source_url) 唯一约束；命中返回 `{existing: true, ...}` + 200
- 解读自动入库：复用 articles 路由的 `_auto_save_vocab` 模式（先占位 → 完成回填 explanation_json）
- 软删：文章软删不级联 vocabulary（已沉淀语言点独立于文章生命周期）
- 抓取失败：400 + `{error: "fetch_failed", hint: "..."}`，前端自动切到粘贴 tab
- Markdown 渲染：MVP 内置简单渲染器（无 marked/DOMPurify 外部依赖，不影响 bundle size budget）

## Test plan

- [ ] `pytest tests/test_v08_library.py -v` → 13 passed
- [ ] 手测：粘贴 URL → 抓回正文 → 点词出气泡 → IPA 秒出 → 展开解读 → 本文沉淀侧栏出现条目
- [ ] 手测：粘贴正文（Markdown 模式）完整流程
- [ ] 手测：抓取失败 → 自动切粘贴 tab
- [ ] 手测：软删文章 → 已沉淀词不丢失

🤖 Generated with [Claude Code](https://claude.com/claude-code)