### PR TITLE
test: 新功能冒烟测试 + 集成测试

### DIFF
--- a/tests/test_integration_new_features.py
+++ b/tests/test_integration_new_features.py
@@ -1,0 +1,234 @@
+"""集成测试 — 跨服务端到端流程验证
+
+不 mock 内部 service，只 mock 外部 LLM。验证：
+  - 翻译 → 占位 → 回填 → 生词本可查 的完整链路
+  - 文章导入 → 解读 → 生词本入库 → 列表可见 的完整链路
+  - 跨 source_type 数据隔离
+user_id: test_user_integration_*
+"""
+import json
+import pytest
+from unittest.mock import patch, AsyncMock, MagicMock
+from httpx import AsyncClient, ASGITransport
+from sqlalchemy.orm import Session as OrmSession
+
+from main import app
+from app.models.db import engine, init_db, Vocabulary, LibraryArticle
+from app.routers.auth import get_current_user_id, get_current_user_id_optional
+
+USER = "test_user_integration_new"
+
+
+@pytest.fixture(autouse=True)
+def setup():
+    init_db()
+    app.dependency_overrides[get_current_user_id] = lambda: USER
+    app.dependency_overrides[get_current_user_id_optional] = lambda: USER
+    with OrmSession(engine) as s:
+        s.query(Vocabulary).filter(Vocabulary.user_id == USER).delete()
+        s.query(LibraryArticle).filter(LibraryArticle.user_id == USER).delete()
+        s.commit()
+    yield
+    with OrmSession(engine) as s:
+        s.query(Vocabulary).filter(Vocabulary.user_id == USER).delete()
+        s.query(LibraryArticle).filter(LibraryArticle.user_id == USER).delete()
+        s.commit()
+    app.dependency_overrides.pop(get_current_user_id, None)
+    app.dependency_overrides.pop(get_current_user_id_optional, None)
+
+
+def _get_vocab_items(source_type=None):
+    with OrmSession(engine) as s:
+        q = s.query(Vocabulary).filter_by(user_id=USER, status="active")
+        if source_type:
+            q = q.filter_by(source_type=source_type)
+        return [
+            {"id": v.id, "source_text": v.source_text, "translated_text": v.translated_text,
+             "source_type": v.source_type, "source_ref": v.source_ref,
+             "item_type": v.item_type, "explanation_json": v.explanation_json}
+            for v in q.all()
+        ]
+
+
+# ── 翻译自动入库完整链路 ──────────────────────────────────
+
+class TestTranslateAutoVocabIntegration:
+    """翻译 → 占位 → LLM 返回 → 回填 → /vocab 可查"""
+
+    @pytest.mark.asyncio
+    async def test_translate_then_vocab_visible(self):
+        """翻译一段文本后，通过 /vocab 端点能查到对应条目"""
+        with patch("app.routers.translate.translate_text",
+                   new_callable=AsyncMock, return_value="Good morning"):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+                resp = await c.post("/translate/text", json={
+                    "text": "早上好", "direction": "zh2en",
+                })
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["saved_to_vocab"] is True
+        vid = data["vocab_id"]
+
+        # 通过 /vocab 端点查询（集成层面，非直查 DB）
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            resp2 = await c.get("/vocab?source_type=translate")
+
+        items = resp2.json()["items"]
+        match = [i for i in items if i["id"] == vid]
+        assert len(match) == 1
+        assert match[0]["source_text"] == "早上好"
+        assert match[0]["translated_text"] == "Good morning"
+        assert match[0]["source_type"] == "translate"
+        assert match[0]["item_type"] == "sentence"
+
+    @pytest.mark.asyncio
+    async def test_translate_twice_same_text_idempotent_in_vocab(self):
+        """翻译同一文本两次，生词本只有一条记录，translated_text 为最新"""
+        for expected in ["v1", "v2"]:
+            with patch("app.routers.translate.translate_text",
+                       new_callable=AsyncMock, return_value=expected):
+                async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+                    await c.post("/translate/text", json={
+                        "text": "重复测试", "direction": "zh2en",
+                    })
+
+        items = _get_vocab_items(source_type="translate")
+        matching = [i for i in items if i["source_text"] == "重复测试"]
+        assert len(matching) == 1
+        assert matching[0]["translated_text"] == "v2"
+
+
+# ── 文章库完整链路 ────────────────────────────────────────
+
+class TestLibraryIntegration:
+    """导入 → 解读 → vocab 入库 → vocab 列表可见"""
+
+    @pytest.mark.asyncio
+    async def test_import_explain_vocab_flow(self):
+        """导入文章 → 解读单词 → 检查 vocab 有 source_type=library 条目"""
+        # 1. 导入文章
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            r1 = await c.post("/library/articles", json={
+                "markdown": "# Integration Test\n\nThe quick brown fox jumps.",
+                "title": "Integration Article",
+            })
+        assert r1.status_code == 201
+        article_id = r1.json()["id"]
+
+        # 2. 解读单词（mock LLM）
+        mock_result = {
+            "explanation": {
+                "phonetic": "/kwɪk/",
+                "meaning": "快的",
+                "meanings": ["快速的", "敏捷的"],
+                "example": "She gave a quick answer.",
+            }
+        }
+        with patch("app.routers.library.explain_text",
+                   new_callable=AsyncMock, return_value=mock_result):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+                r2 = await c.post(f"/library/articles/{article_id}/explain", json={
+                    "text": "quick", "kind": "word", "context": "The quick brown fox",
+                })
+        assert r2.status_code == 200
+
+        # 3. 检查 vocab — source_type=library 有条目
+        items = _get_vocab_items(source_type="library")
+        match = [i for i in items if i["source_text"] == "quick"]
+        assert len(match) == 1
+        assert match[0]["source_ref"] == str(article_id)
+        assert match[0]["item_type"] == "word"
+        # explanation_json 已回填
+        exp = json.loads(match[0]["explanation_json"])
+        assert exp["phonetic"] == "/kwɪk/"
+        assert exp["meaning"] == "快的"
+
+    @pytest.mark.asyncio
+    async def test_library_phonetic_creates_vocab_entry(self):
+        """phonetic 端点也会创建 vocab 占位条目"""
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            r1 = await c.post("/library/articles", json={
+                "markdown": "# Phonetic\n\nHello world.", "title": "Phonetic Test",
+            })
+        article_id = r1.json()["id"]
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            r2 = await c.post(f"/library/articles/{article_id}/explain/phonetic", json={
+                "text": "hello",
+            })
+        assert r2.status_code == 200
+        assert "phonetic" in r2.json()
+
+        items = _get_vocab_items(source_type="library")
+        match = [i for i in items if i["source_text"] == "hello"]
+        assert len(match) == 1
+        assert match[0]["source_ref"] == str(article_id)
+
+    @pytest.mark.asyncio
+    async def test_delete_article_does_not_cascade_vocab(self):
+        """软删文章后，vocab 条目仍存在（不级联）"""
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            r1 = await c.post("/library/articles", json={
+                "markdown": "# Cascade\n\nTest cascade.", "title": "Cascade",
+            })
+        article_id = r1.json()["id"]
+
+        # 先通过 phonetic 创建 vocab 条目
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            await c.post(f"/library/articles/{article_id}/explain/phonetic", json={
+                "text": "cascade",
+            })
+
+        # 删文章
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            await c.delete(f"/library/articles/{article_id}")
+
+        # vocab 仍在
+        items = _get_vocab_items(source_type="library")
+        assert any(i["source_text"] == "cascade" for i in items)
+
+
+# ── 跨 source_type 数据隔离 ──────────────────────────────
+
+class TestCrossSourceTypeIsolation:
+    """不同来源的 vocab 条目互不干扰"""
+
+    @pytest.mark.asyncio
+    async def test_translate_and_library_vocab_isolated(self):
+        """同一用户翻译入库和文章解读入库分别在不同 source_type 下"""
+        # 翻译
+        with patch("app.routers.translate.translate_text",
+                   new_callable=AsyncMock, return_value="Hello"):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+                await c.post("/translate/text", json={
+                    "text": "你好", "direction": "zh2en",
+                })
+
+        # 文章
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            r1 = await c.post("/library/articles", json={
+                "markdown": "# Isolation\n\nfoo bar.", "title": "Iso",
+            })
+        article_id = r1.json()["id"]
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            await c.post(f"/library/articles/{article_id}/explain/phonetic", json={
+                "text": "foo",
+            })
+
+        # 分别查询
+        translate_items = _get_vocab_items(source_type="translate")
+        library_items = _get_vocab_items(source_type="library")
+
+        assert len(translate_items) >= 1
+        assert all(i["source_type"] == "translate" for i in translate_items)
+
+        assert len(library_items) >= 1
+        assert all(i["source_type"] == "library" for i in library_items)
+
+        # translate 里没有 library 的，反之亦然
+        translate_texts = {i["source_text"] for i in translate_items}
+        library_texts = {i["source_text"] for i in library_items}
+        assert "foo" not in translate_texts
+        assert "你好" not in library_texts

--- a/tests/test_smoke_new_features.py
+++ b/tests/test_smoke_new_features.py
@@ -1,0 +1,145 @@
+"""冒烟测试 — 新功能端点存活性检查
+
+所有新增端点能正常返回（不 500），不依赖 LLM，仅验证路由注册 + 基本参数校验。
+user_id: test_user_smoke_*
+"""
+import pytest
+from fastapi.testclient import TestClient
+
+from main import app
+from app.models.db import engine, init_db
+from app.routers.auth import get_current_user_id, get_current_user_id_optional
+
+USER = "test_user_smoke"
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _setup():
+    init_db()
+    app.dependency_overrides[get_current_user_id] = lambda: USER
+    app.dependency_overrides[get_current_user_id_optional] = lambda: USER
+    yield
+    app.dependency_overrides.pop(get_current_user_id, None)
+    app.dependency_overrides.pop(get_current_user_id_optional, None)
+
+
+# ── #53 翻译自动入库 ──────────────────────────────────────
+
+class TestTranslateAutoVocabSmoke:
+    """POST /translate/text 返回新增字段 saved_to_vocab / vocab_id"""
+
+    def test_translate_text_returns_new_fields(self):
+        """即使翻译失败（mock 缺失），响应 schema 仍含 saved_to_vocab 字段"""
+        resp = client.post("/translate/text", json={"text": "", "direction": "zh2en"})
+        assert resp.status_code == 400  # 空文本 → 400，路由能到达
+
+    def test_translate_text_invalid_direction_400(self):
+        resp = client.post("/translate/text", json={"text": "hello", "direction": "bad"})
+        assert resp.status_code == 400
+        assert "无效" in resp.json()["detail"]
+
+    def test_translate_text_too_long_400(self):
+        resp = client.post("/translate/text", json={"text": "a" * 1001, "direction": "zh2en"})
+        assert resp.status_code == 400
+
+
+# ── #54 文章库 ─────────────────────────────────────────────
+
+class TestLibrarySmoke:
+    """所有 /library/* 端点能到达且参数校验正常"""
+
+    def test_list_articles_200(self):
+        resp = client.get("/library/articles")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "articles" in data
+        assert "page" in data
+
+    def test_import_article_no_body_400(self):
+        resp = client.post("/library/articles", json={})
+        assert resp.status_code == 400
+
+    def test_import_article_markdown_201(self):
+        resp = client.post("/library/articles", json={
+            "markdown": "# Test\n\nHello world.",
+            "title": "Smoke Test Article",
+        })
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["title"] == "Smoke Test Article"
+        article_id = data["id"]
+
+        # 详情
+        resp2 = client.get(f"/library/articles/{article_id}")
+        assert resp2.status_code == 200
+        assert resp2.json()["markdown"] == "# Test\n\nHello world."
+
+        # 软删
+        resp3 = client.delete(f"/library/articles/{article_id}")
+        assert resp3.status_code == 200
+        assert resp3.json()["deleted"] is True
+
+        # 删后 404
+        resp4 = client.get(f"/library/articles/{article_id}")
+        assert resp4.status_code == 404
+
+    def test_get_nonexistent_article_404(self):
+        resp = client.get("/library/articles/999999")
+        assert resp.status_code == 404
+
+    def test_explain_phonetic_no_text_400(self):
+        # 先创建一篇文章
+        art = client.post("/library/articles", json={
+            "markdown": "# Smoke\n\nword.", "title": "Phonetic Smoke",
+        }).json()
+        resp = client.post(f"/library/articles/{art['id']}/explain/phonetic", json={"text": ""})
+        assert resp.status_code == 400
+
+    def test_explain_phonetic_returns_ipa(self):
+        art = client.post("/library/articles", json={
+            "markdown": "# IPA\n\nHello.", "title": "IPA Smoke",
+        }).json()
+        resp = client.post(f"/library/articles/{art['id']}/explain/phonetic", json={"text": "hello"})
+        assert resp.status_code == 200
+        assert "phonetic" in resp.json()
+
+    def test_refetch_paste_mode_400(self):
+        art = client.post("/library/articles", json={
+            "markdown": "# No URL", "title": "Paste",
+        }).json()
+        resp = client.post(f"/library/articles/{art['id']}/refetch")
+        assert resp.status_code == 400
+
+
+# ── #55 DeepL 重设计（前端纯静态路由）──────────────────────
+
+class TestDeepLSmoke:
+    """/translate 前端页面路由存活"""
+
+    def test_translate_page_not_500(self):
+        """确认 /translate 路由不返回 500（Vue SPA 由前端路由处理）"""
+        # 在 API 层面，/translate 不是 API 端点（由前端路由处理）
+        # 但翻译 API 端点 /translate/text 应可达
+        resp = client.post("/translate/text", json={"text": "test", "direction": "en2zh"})
+        # 可能 503（LLM 不可用）或 200，不应 500/404
+        assert resp.status_code in (200, 503)
+
+
+# ── 通用 /vocab 端点冒烟 ──────────────────────────────────
+
+class TestVocabSmoke:
+    """生词本列表端点可达 + source_type 过滤"""
+
+    def test_vocab_list_200(self):
+        resp = client.get("/vocab")
+        assert resp.status_code == 200
+        assert "items" in resp.json()
+
+    def test_vocab_list_with_source_type_filter(self):
+        resp = client.get("/vocab?source_type=translate")
+        assert resp.status_code == 200
+
+    def test_vocab_list_with_source_type_library(self):
+        resp = client.get("/vocab?source_type=library")
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- 14 个冒烟测试：验证所有新端点存活性 + 参数校验
- 6 个集成测试：跨服务端到端流程验证（翻译→vocab、文章→解读→vocab、数据隔离）

## Test plan
- [x] 20/20 全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)