### PR TITLE
chore(compose): 精简 dev-web env · 移除冗余 LOG_DIR

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,6 @@ services:
       # SQLite 落到挂载卷 · 容器重启/镜像更新数据不丢
       DATABASE_URL: sqlite+aiosqlite:////app/data/speakeasy.db
       SPEAKEASY_DB_PATH: /app/data/speakeasy.db
-      # 日志落到 /app/logs（挂 named volume，宿主机可 `docker compose exec` 查看或挂主机目录持久化）
-      LOG_DIR: /app/logs
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - logs:/app/logs


### PR DESCRIPTION
## Summary

PR #60 留下的小尾巴：`docker-compose.yml` 里 `LOG_DIR: /app/logs` 这个 env 是冗余的——`app/logger.py:20` 默认 `LOG_DIR="logs"`，配合 `Dockerfile:22 WORKDIR /app` 解析为 `/app/logs`，与挂载点完全一致。显式 env 没有效果上的差异，删掉。

## Diff

```diff
       SPEAKEASY_DB_PATH: /app/data/speakeasy.db
-      # 日志落到 /app/logs（挂 named volume，宿主机可 `docker compose exec` 查看或挂主机目录持久化）
-      LOG_DIR: /app/logs
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - logs:/app/logs
```

只动 `docker-compose.yml`，2 行删除，无功能变更。

## Test plan

- [x] 本地容器跑 `app/logger.py` 默认值，日志仍写到 `/app/logs/app.log`
- [ ] 合并后 GitHub Actions 部署成功
- [ ] VPS 上 `docker compose exec dev-web env | grep LOG` 不再出现 LOG_DIR，`/app/logs/app.log` 正常追加


---
_Generated by [Claude Code](https://claude.ai/code/session_0196zGVc7pLoNaypQLM7vodN)_